### PR TITLE
fix: add Arch Linux compatibility for hostname command

### DIFF
--- a/script/clashctl.sh
+++ b/script/clashctl.sh
@@ -114,7 +114,11 @@ function clashui() {
     local public_address="http://${public_ip:-公网}:${UI_PORT}/ui"
     # 内网ip
     # ip route get 1.1.1.1 | grep -oP 'src \K\S+'
-    local local_ip=$(hostname -I | awk '{print $1}')
+    if grep -q "ID=arch" /etc/os-release 2>/dev/null; then
+        local local_ip=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+' 2>/dev/null)
+    else
+        local local_ip=$(hostname -I | awk '{print $1}' 2>/dev/null)
+    fi
     local local_address="http://${local_ip}:${UI_PORT}/ui"
     printf "\n"
     printf "╔═══════════════════════════════════════════════╗\n"

--- a/script/clashctl.sh
+++ b/script/clashctl.sh
@@ -188,7 +188,7 @@ _tunon() {
     }
 
     # 开启TUN模式时卸载环境变量，避免冲突
-    _unset_proxy_env
+    _unset_system_proxy
     _okcat "Tun 模式已开启，已自动卸载环境变量代理"
 }
 


### PR DESCRIPTION
arch linux 下无法通过 `hostname -I` 获取内网 ip，添加判断，如果是 arch 的话使用 `ip route get 1.1.1.1 | grep -oP 'src \K\S+'` 获取内网 ip