### PR TITLE
支持rhel衍生的常用os定时任务路径rocky/almalinux/openEuler，debian/ubuntu保持不变

### DIFF
--- a/script/common.sh
+++ b/script/common.sh
@@ -62,7 +62,7 @@ _set_var() {
 
     # 定时任务路径
     local os_info=$(cat /etc/os-release)
-    echo "$os_info" | grep -iqsE "rhel|centos" && CLASH_CRON_TAB="/var/spool/cron/$user"
+    echo "$os_info" | grep -iqsE "rhel|centos|openEuler|Rocky|AlmaLinux" && CLASH_CRON_TAB="/var/spool/cron/$user"
     echo "$os_info" | grep -iqsE "debian|ubuntu" && CLASH_CRON_TAB="/var/spool/cron/crontabs/$user"
 }
 _set_var


### PR DESCRIPTION
rhel多用海外生产环境，centos7已经EOL目前常用rhel系主要是rocky、almalinux、openEuler

[root@controller-amd64-p4-25-91 github]# source /opt/clash/script/common.sh
[root@controller-amd64-p4-25-91 github]# cat /opt/clash/script/common.sh  |grep rhel
    echo "$os_info" | grep -iqsE "rhel|centos|openEuler|Rocky|AlmaLinux" && CLASH_CRON_TAB="/var/spool/cron/$user"
[root@controller-amd64-p4-25-91 github]# clashctl update auto
😼 已设置定时更新订阅
[root@controller-amd64-p4-25-91 github]# cat /var/spool/cron/root  |grep clash
0 0 */2 * * bash -i -c 'clashupdate https://example.com'
[root@controller-amd64-p4-25-91 github]# cat /etc/os-release
NAME="openEuler"
VERSION="22.03 (LTS-SP3)"
ID="openEuler"
VERSION_ID="22.03"
PRETTY_NAME="openEuler 22.03 (LTS-SP3)"
ANSI_COLOR="0;31"