### PR TITLE
fix: remove shift to prevent error when no arguments in Zsh

### DIFF
--- a/script/clashctl.sh
+++ b/script/clashctl.sh
@@ -354,7 +354,6 @@ function clashctl() {
         clashupgrade "$@"
         ;;
     *)
-        shift
         clashhelp "$@"
         ;;
     esac


### PR DESCRIPTION
### **Describe the bug**

When installing via:

```bash
sudo zsh install.sh
```

the script prints the following error during execution:

```
clashctl:shift:40: shift count must be <= $#
```

### **Root Cause (Analysis)**

Inside `clashctl()` and related subcommands, several case branches contain unconditional `shift` calls, e.g.:

```bash
    *)
        shift
        clashhelp "$@"
        ;;
```

If `clashctl` is invoked without additional arguments (as happens during installation), `$# = 0`, causing:

```
shift: shift count must be <= $#
```

The issue does not appear when running the installer under bash. but zsh is stricter than bash in this case.

The difference is due to shell-specific behavior for shift when `$# = 0`. Bash is more permissive, while Zsh strictly enforces the rule. Bash does not report this, but Zsh does, causing unnecessary noise.  To prevent this, `shift` should be used carefully.

### **Fix**

The PR removes the redundant `shift`:

* Prevents the Zsh error when no arguments are provided
* Since argument shifting is unnecessary here — this branch always prints the clashhelp message regardless of the input parameters.


### **Environment**

* Shell: `zsh`
* Install command: `sudo zsh install.sh`