### PR TITLE
fix: rename 'path' to 'profile_path' to avoid zsh variable conflict

### DIFF
--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -534,14 +534,14 @@ _sub_add() {
     转换日志：$BIN_SUBCONVERTER_LOG"
 
     local id=$("$BIN_YQ" '.profiles // [] | (map(.id) | max) // 0 | . + 1' "$CLASH_PROFILES_META")
-    local path="${CLASH_PROFILES_DIR}/${id}.yaml"
-    mv "$CLASH_CONFIG_TEMP" "$path"
+    local profile_path="${CLASH_PROFILES_DIR}/${id}.yaml"
+    mv "$CLASH_CONFIG_TEMP" "$profile_path"
 
     "$BIN_YQ" -i "
          .profiles = (.profiles // []) + 
          [{
            \"id\": $id,
-           \"path\": \"$path\",
+           \"path\": \"$profile_path\",
            \"url\": \"$url\"
          }]
     " "$CLASH_PROFILES_META"
@@ -555,12 +555,12 @@ _sub_del() {
         read -r id
         [ -z "$id" ] && _error_quit "订阅 id 不能为空"
     }
-    local path url
-    path=$(_get_path_by_id "$id") || _error_quit "订阅 id 不存在，请检查"
+    local profile_path url
+    profile_path=$(_get_path_by_id "$id") || _error_quit "订阅 id 不存在，请检查"
     url=$(_get_url_by_id "$id")
     use=$("$BIN_YQ" '.use // ""' "$CLASH_PROFILES_META")
     [ "$use" = "$id" ] && _error_quit "删除失败：订阅 $id 正在使用中，请先切换订阅"
-    /usr/bin/rm -f "$path"
+    /usr/bin/rm -f "$profile_path"
     "$BIN_YQ" -i "del(.profiles[] | select(.id == \"$id\"))" "$CLASH_PROFILES_META"
     _logging_sub "➖ 已删除订阅：[$id] $url"
     _okcat '🎉' "订阅已删除：[$id] $url"
@@ -578,10 +578,10 @@ _sub_use() {
         read -r id
         [ -z "$id" ] && _error_quit "订阅 id 不能为空"
     }
-    local path url
-    path=$(_get_path_by_id "$id") || _error_quit "订阅 id 不存在，请检查"
+    local profile_path url
+    profile_path=$(_get_path_by_id "$id") || _error_quit "订阅 id 不存在，请检查"
     url=$(_get_url_by_id "$id")
-    cat "$path" >"$CLASH_CONFIG_BASE"
+    cat "$profile_path" >"$CLASH_CONFIG_BASE"
     _merge_config_restart
     "$BIN_YQ" -i ".use = $id" "$CLASH_PROFILES_META"
     _logging_sub "🔥 订阅已切换为：[$id] $url"
@@ -616,9 +616,9 @@ _sub_update() {
     done
     local id=$1
     [ -z "$id" ] && id=$("$BIN_YQ" '.use // 1' "$CLASH_PROFILES_META")
-    local url path
+    local url profile_path
     url=$(_get_url_by_id "$id") || _error_quit "订阅 id 不存在，请检查"
-    path=$(_get_path_by_id "$id")
+    profile_path=$(_get_path_by_id "$id")
     _okcat "✈️ " "更新订阅：[$id] $url"
 
     [ "$is_convert" = true ] && {
@@ -635,7 +635,7 @@ _sub_update() {
     转换日志：$BIN_SUBCONVERTER_LOG"
     }
     _logging_sub "✅ 订阅更新成功：[$id] $url"
-    cat "$CLASH_CONFIG_TEMP" >"$path"
+    cat "$CLASH_CONFIG_TEMP" >"$profile_path"
     use=$("$BIN_YQ" '.use // ""' "$CLASH_PROFILES_META")
     [ "$use" = "$id" ] && clashsub use "$use" && return
     _okcat '订阅已更新'


### PR DESCRIPTION
## Summary

Fixes #420 

## Changes

In zsh, 'path' is a special array variable that is tied to the PATH environment variable. Using 'path' as a local variable can corrupt the system PATH, causing commands to become unavailable.

This fix renames all instances of 'path' variable in subscription management functions (_sub_add, _sub_del, _sub_use, _sub_update) to 'profile_path' to avoid this conflict.

Affected functions:
- _sub_add(): line 537
- _sub_del(): lines 558-563
- _sub_use(): lines 581-584
- _sub_update(): lines 619-638

Tested on zsh 5.9 - PATH environment variable is now preserved after running subscription commands.

## Result
<img width="925" height="683" alt="image" src="https://github.com/user-attachments/assets/29f9dfd3-4bfd-43bb-b9b7-0131aaa34077" />
