### PR TITLE
fix: resolve zsh compatibility issue with indirect expansion in clasctl

### DIFF
--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -54,10 +54,13 @@ _detect_proxy_port() {
     for entry in "${port_list[@]}"; do
         local var_name="${entry%|*}"
         local yaml_key="${entry#*|}"
-        [ -n "${!var_name}" ] && _is_port_used "${!var_name}" && [ "$isActive" != "true" ] && {
+
+        eval "local var_val=\${$var_name}"
+
+        [ -n "$var_val" ] && _is_port_used "$var_val" && [ "$isActive" != "true" ] && {
             newPort=$(_get_random_port)
             ((count++))
-            _failcat '🎯' "端口冲突：[$yaml_key] ${!var_name} 🎲 随机分配 $newPort"
+            _failcat '🎯' "端口冲突：[$yaml_key] $var_val 🎲 随机分配 $newPort"
             "$BIN_YQ" -i ".${yaml_key} = $newPort" "$CLASH_CONFIG_MIXIN"
         }
     done


### PR DESCRIPTION
关联 Issue: #446

修改说明:
此 PR 修复了在 zsh 环境下运行脚本时出现的语法兼容性错误：_detect_proxy_port:16: bad substitution。

问题原因:
原代码在 [clashctl.sh](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 中使用了 Bash 特有的间接变量引用语法 ${!var}。当脚本在 zsh 环境中被加载或执行时，zsh 无法识别该语法从而导致报错。

修复方案:
将 ${!var_name} 修改为通用的 eval 方式来动态获取变量值。这样做确保了代码能够同时兼容 Bash 和 Zsh 环境