### PR TITLE
New Line Before $start_flag

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -359,6 +359,7 @@ _apply_rc() {
     local source_clashctl=". $CLASH_CMD_DIR/clashctl.sh"
     # shellcheck disable=SC2086
     tee -a "$SHELL_RC_BASH" $SHELL_RC_ZSH >/dev/null <<EOF
+
 $start_flag
 # 加载 clashctl 命令
 $source_clashctl


### PR DESCRIPTION
When installing, if the user's `.bashrc` lacks a trailing newline, the configuration will be appended directly to the last line of the existing content. For example, if the file ends with `my_command`, it results in `my_command# clashctl START`, which is unexpected.

(This should be an issue, but since it is easy to fix, I have just made a PR.)