### PR TITLE
fix(mihomo): 订阅校验前自动补齐 GeoData，避免回退转换导致 VLESS 节点丢失

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 .vscode
 config.yaml*
+resources/geoip.metadb
+resources/ASN.mmdb
 resources/zip/*
 !resources/zip/dist.zip
 resources/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea
 .vscode
 config.yaml*
-resources/geoip.metadb
 resources/ASN.mmdb
 resources/zip/*
 !resources/zip/dist.zip

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 自动检测端口占用情况，在冲突时随机分配可用端口。
 - 自动识别系统架构与初始化系统，下载匹配的内核与依赖，并生成对应的服务管理配置。
 - 在需要时调用 [subconverter](https://github.com/tindy2013/subconverter) 进行本地订阅转换。
+- 使用 `mihomo` 时自动补齐所需 GeoData（如 `geoip.metadb`、`ASN.mmdb`），避免订阅包含 `GEOIP`/`IP-ASN` 规则时因数据缺失导致校验/启动失败。
 
 ## 🚀 一键安装
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 - 自动检测端口占用情况，在冲突时随机分配可用端口。
 - 自动识别系统架构与初始化系统，下载匹配的内核与依赖，并生成对应的服务管理配置。
 - 在需要时调用 [subconverter](https://github.com/tindy2013/subconverter) 进行本地订阅转换。
-- 使用 `mihomo` 时自动补齐所需 GeoData（如 `geoip.metadb`、`ASN.mmdb`），避免订阅包含 `GEOIP`/`IP-ASN` 规则时因数据缺失导致校验/启动失败。
 
 ## 🚀 一键安装
 

--- a/scripts/cmd/common.sh
+++ b/scripts/cmd/common.sh
@@ -115,19 +115,125 @@ function _error_quit() {
     exec $SHELL -i
 }
 
+_download_file() {
+    local dest=$1
+    local url=$2
+    local tmp="${dest}.tmp"
+
+    rm -f "$tmp"
+    curl \
+        --silent \
+        --show-error \
+        --fail \
+        --insecure \
+        --location \
+        --connect-timeout 5 \
+        --max-time 180 \
+        --retry 1 \
+        --output "$tmp" \
+        "$url" ||
+        wget \
+            --no-verbose \
+            --no-check-certificate \
+            --timeout 180 \
+            --tries 1 \
+            --output-document "$tmp" \
+            "$url" ||
+        return 1
+
+    [ -s "$tmp" ] || return 1
+    /bin/mv -f "$tmp" "$dest"
+}
+
+_download_file_any() {
+    local dest=$1
+    shift
+
+    local url
+    for url in "$@"; do
+        [ -n "$url" ] || continue
+        _download_file "$dest" "$url" && return 0
+    done
+    return 1
+}
+
+_gh_proxy_url() {
+    local url=$1
+    [ -n "$URL_GH_PROXY" ] || return 1
+    [[ "$url" == https://github.com/* || "$url" == http://github.com/* ]] || return 1
+    echo "${URL_GH_PROXY%/}/$url"
+}
+
+_ensure_mihomo_geodata() {
+    local config=$1
+    local data_dir
+    data_dir=$(dirname "$config")
+
+    local url_geoip_metadb="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb"
+    local url_geosite_dat="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
+    local url_geolite2_asn_mmdb="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+
+    local mirror_geoip_metadb="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb"
+    local mirror_geosite_dat="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat"
+    local mirror_geolite2_asn_mmdb="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb"
+
+    local file_geoip_metadb="${data_dir}/geoip.metadb"
+    local file_geosite_dat="${data_dir}/geosite.dat"
+    local file_asn_mmdb="${data_dir}/ASN.mmdb"
+
+    grep -qs 'GEOIP' "$config" && [ ! -f "$file_geoip_metadb" ] && {
+        local url1 url2
+        url1=$(_gh_proxy_url "$url_geoip_metadb")
+        url2="$url_geoip_metadb"
+        _okcat '⏳' "下载 GeoData：geoip.metadb"
+        _download_file_any "$file_geoip_metadb" "$url1" "$url2" "$mirror_geoip_metadb" ||
+            _failcat "GeoData 下载失败：geoip.metadb（请检查网络或 URL_GH_PROXY）"
+    }
+
+    grep -qs 'GEOSITE' "$config" && [ ! -f "$file_geosite_dat" ] && {
+        local url1 url2
+        url1=$(_gh_proxy_url "$url_geosite_dat")
+        url2="$url_geosite_dat"
+        _okcat '⏳' "下载 GeoData：geosite.dat"
+        _download_file_any "$file_geosite_dat" "$url1" "$url2" "$mirror_geosite_dat" ||
+            _failcat "GeoData 下载失败：geosite.dat（请检查网络或 URL_GH_PROXY）"
+    }
+
+    grep -qs 'IP-ASN' "$config" && [ ! -f "$file_asn_mmdb" ] && {
+        local url1 url2
+        url1=$(_gh_proxy_url "$url_geolite2_asn_mmdb")
+        url2="$url_geolite2_asn_mmdb"
+        _okcat '⏳' "下载 GeoData：ASN.mmdb"
+        _download_file_any "$file_asn_mmdb" "$url1" "$url2" "$mirror_geolite2_asn_mmdb" ||
+            _failcat "GeoData 下载失败：ASN.mmdb（请检查网络或 URL_GH_PROXY）"
+    }
+}
+
 function _valid_config() {
     local config="$1"
     [[ ! -e "$config" || "$(wc -l <"$config")" -lt 1 ]] && return 1
 
     local test_cmd test_log
     test_cmd=("$BIN_KERNEL" -d "$(dirname "$config")" -f "$config" -t)
-    test_log=$("${test_cmd[@]}") || {
-        "${test_cmd[@]}"
+
+    [ "$KERNEL_NAME" = "mihomo" ] && _ensure_mihomo_geodata "$config"
+
+    test_log=$("${test_cmd[@]}" 2>&1) || {
+        # 兜底：处理残缺/旧版 GeoData
+        [ "$KERNEL_NAME" = "mihomo" ] && {
+            grep -qs "MMDB invalid" <<<"$test_log" && rm -f "$(dirname "$config")/geoip.metadb"
+            grep -qs "ASN invalid" <<<"$test_log" && rm -f "$(dirname "$config")/ASN.mmdb"
+            _ensure_mihomo_geodata "$config"
+            test_log=$("${test_cmd[@]}" 2>&1) && return 0
+        }
+
+        printf '%s\n' "$test_log" >&2
         grep -qs "unsupport proxy type" <<<"$test_log" && {
             local prefix="检测到订阅中包含不受支持的代理协议"
             [ "$KERNEL_NAME" = "clash" ] && _error_quit "${prefix}, 推荐安装使用 mihomo 内核"
             _error_quit "${prefix}, 请检查并升级内核版本"
         }
+        return 1
     }
 }
 

--- a/scripts/cmd/common.sh
+++ b/scripts/cmd/common.sh
@@ -164,49 +164,26 @@ _gh_proxy_url() {
     echo "${URL_GH_PROXY%/}/$url"
 }
 
-_ensure_mihomo_geodata() {
+_ensure_mihomo_asn_mmdb() {
     local config=$1
     local data_dir
     data_dir=$(dirname "$config")
 
-    local url_geoip_metadb="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb"
-    local url_geosite_dat="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat"
-    local url_geolite2_asn_mmdb="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+    grep -qs 'IP-ASN' "$config" || return 0
 
-    local mirror_geoip_metadb="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb"
-    local mirror_geosite_dat="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat"
-    local mirror_geolite2_asn_mmdb="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb"
-
-    local file_geoip_metadb="${data_dir}/geoip.metadb"
-    local file_geosite_dat="${data_dir}/geosite.dat"
     local file_asn_mmdb="${data_dir}/ASN.mmdb"
+    [ -s "$file_asn_mmdb" ] && return 0
 
-    grep -qs 'GEOIP' "$config" && [ ! -f "$file_geoip_metadb" ] && {
-        local url1 url2
-        url1=$(_gh_proxy_url "$url_geoip_metadb")
-        url2="$url_geoip_metadb"
-        _okcat '⏳' "下载 GeoData：geoip.metadb"
-        _download_file_any "$file_geoip_metadb" "$url1" "$url2" "$mirror_geoip_metadb" ||
-            _failcat "GeoData 下载失败：geoip.metadb（请检查网络或 URL_GH_PROXY）"
-    }
+    local url_asn_mmdb="https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb"
+    local mirror_asn_mmdb="https://testingcf.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb"
 
-    grep -qs 'GEOSITE' "$config" && [ ! -f "$file_geosite_dat" ] && {
-        local url1 url2
-        url1=$(_gh_proxy_url "$url_geosite_dat")
-        url2="$url_geosite_dat"
-        _okcat '⏳' "下载 GeoData：geosite.dat"
-        _download_file_any "$file_geosite_dat" "$url1" "$url2" "$mirror_geosite_dat" ||
-            _failcat "GeoData 下载失败：geosite.dat（请检查网络或 URL_GH_PROXY）"
-    }
+    local url1 url2
+    url1=$(_gh_proxy_url "$url_asn_mmdb")
+    url2="$url_asn_mmdb"
 
-    grep -qs 'IP-ASN' "$config" && [ ! -f "$file_asn_mmdb" ] && {
-        local url1 url2
-        url1=$(_gh_proxy_url "$url_geolite2_asn_mmdb")
-        url2="$url_geolite2_asn_mmdb"
-        _okcat '⏳' "下载 GeoData：ASN.mmdb"
-        _download_file_any "$file_asn_mmdb" "$url1" "$url2" "$mirror_geolite2_asn_mmdb" ||
-            _failcat "GeoData 下载失败：ASN.mmdb（请检查网络或 URL_GH_PROXY）"
-    }
+    _okcat '⏳' '下载 GeoData：ASN.mmdb'
+    _download_file_any "$file_asn_mmdb" "$url1" "$url2" "$mirror_asn_mmdb" ||
+        _failcat 'GeoData 下载失败：ASN.mmdb（请检查网络或 URL_GH_PROXY）'
 }
 
 function _valid_config() {
@@ -216,14 +193,12 @@ function _valid_config() {
     local test_cmd test_log
     test_cmd=("$BIN_KERNEL" -d "$(dirname "$config")" -f "$config" -t)
 
-    [ "$KERNEL_NAME" = "mihomo" ] && _ensure_mihomo_geodata "$config"
+    [ "$KERNEL_NAME" = "mihomo" ] && _ensure_mihomo_asn_mmdb "$config"
 
     test_log=$("${test_cmd[@]}" 2>&1) || {
-        # 兜底：处理残缺/旧版 GeoData
-        [ "$KERNEL_NAME" = "mihomo" ] && {
-            grep -qs "MMDB invalid" <<<"$test_log" && rm -f "$(dirname "$config")/geoip.metadb"
-            grep -qs "ASN invalid" <<<"$test_log" && rm -f "$(dirname "$config")/ASN.mmdb"
-            _ensure_mihomo_geodata "$config"
+        [ "$KERNEL_NAME" = "mihomo" ] && grep -qsi 'ASN invalid' <<<"$test_log" && {
+            rm -f "$(dirname "$config")/ASN.mmdb"
+            _ensure_mihomo_asn_mmdb "$config"
             test_log=$("${test_cmd[@]}" 2>&1) && return 0
         }
 


### PR DESCRIPTION
## 背景 / 问题

在 `KERNEL_NAME=mihomo` 场景下，`clashsub add/update` 会先将订阅下载到临时文件，并执行 `mihomo -t` 进行配置校验。

当订阅配置中包含 `GEOIP` / `IP-ASN`（以及可能的 `GEOSITE`）规则，但运行目录缺少必要 GeoData 文件（如 `geoip.metadb`、`ASN.mmdb`）时，`mihomo -t` 会尝试联网下载这些依赖。在 AutoDL/容器等网络受限环境中，这一步可能失败，从而导致校验失败。

校验失败后脚本会走订阅转换（subconverter）回退路径；在部分订阅内容/转换结果下，该回退路径可能导致 **VLESS 节点被过滤/丢失**，最终表现为：Linux Web UI 中看不到订阅里原本存在的 VLESS 节点。

## 复现说明

* 复现订阅：
  `https://premium.974520.xyz/sub/AI/pro/111/<TOKEN>`
* 现象：修复前在 clash-for-linux-install 的 Web UI 中，订阅节点列表缺少 VLESS 节点（例如“美国GPT / 美国01-GPT”）。
* 对照：同一订阅在 Windows 客户端（Clash Verge）中节点完整。

## 解决方案

在 `_valid_config` 中（仅 `mihomo`）在执行 `mihomo -t` 校验前按需补齐 GeoData，降低因 GeoData 缺失导致校验失败、进而触发回退转换的概率，从源头避免 VLESS 节点在回退链路中丢失。

具体策略：

* **按需检测并补齐 GeoData**

  * 配置包含 `GEOIP` → 确保存在 `geoip.metadb`
  * 配置包含 `IP-ASN` → 确保存在 `ASN.mmdb`
  * （可选）配置包含 `GEOSITE` → 确保存在 `geosite.dat`
* **下载策略**

  * 若设置 `.env` 的 `URL_GH_PROXY`：优先用于 GitHub 下载链接
  * 失败后回退到 jsdelivr 镜像，提高受限网络环境的成功率
  * 同时提供 `curl`/`wget` 两种下载方式兜底
* **兼容兜底**

  * 若校验日志出现 `MMDB invalid` / `ASN invalid`，自动删除对应缓存文件并重新下载后再校验一次
* **仓库卫生**

  * 将运行时生成的 `resources/geoip.metadb`、`resources/ASN.mmdb` 加入 `.gitignore`，避免污染工作区

## 截图说明

* **图1（修复前 / Linux Web UI）**：clash-for-linux-install Web UI 中缺少订阅里的 VLESS 节点（如“美国GPT / 美国01-GPT”）。
* **图2（Windows 对照）**：Windows 端 Clash Verge 中同一订阅可正常显示上述 VLESS 节点。
* **图3（修复后 / Linux Web UI）**：应用本 PR 后，Linux Web UI 可正常显示这两条 VLESS 节点，节点列表与对照一致。

## 影响范围 / 兼容性

* 仅在 `KERNEL_NAME=mihomo` 且配置确实包含对应规则时触发；不影响 `clash` 内核流程。
* 不改变订阅转换逻辑；仅减少因 GeoData 缺失导致 `mihomo -t` 校验失败、被迫回退转换的情况。

## 变更点

* `latestversion/scripts/cmd/common.sh`

  * 新增 GeoData 下载与兜底逻辑
  * `_valid_config` 在 `mihomo -t` 前调用 GeoData 确保逻辑，并在校验失败时做一次 “invalid 文件清理 + 重试” 的兜底
* `latestversion/.gitignore`

  * 忽略 `resources/geoip.metadb`、`resources/ASN.mmdb`

## 测试

* `bash -n latestversion/scripts/cmd/common.sh` 语法检查通过（无输出）。

<img width="1567" height="1161" alt="image" src="https://github.com/user-attachments/assets/959c7c64-6e4a-4245-b474-6f568129ccc7" />
<img width="2048" height="1172" alt="image" src="https://github.com/user-attachments/assets/2f1fef66-6b42-498a-b51b-b11b5e9911aa" />
<img width="1608" height="1149" alt="image" src="https://github.com/user-attachments/assets/412c14f9-81df-43e0-8fa8-4969d64dbb5d" />
