### PR TITLE
代理增加随机用户名和密码，防止在多用户机器上被蹭流量

### DIFF
--- a/scripts/cmd/common.sh
+++ b/scripts/cmd/common.sh
@@ -22,6 +22,10 @@ CLASH_PROFILES_DIR="${CLASH_RESOURCES_DIR}/profiles"
 CLASH_PROFILES_META="${CLASH_RESOURCES_DIR}/profiles.yaml"
 CLASH_PROFILES_LOG="${CLASH_RESOURCES_DIR}/profiles.log"
 
+_get_random_val() {
+    cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 6
+}
+
 _is_port_used() {
     local port=$1
     { ss -tunl 2>/dev/null || netstat -tunl; } | grep -qs ":${port}\b"


### PR DESCRIPTION
在多用户 Linux 服务器环境下，代理端口若未启用认证，可能被其他用户直接使用，造成流量被蹭或带宽滥用。