### PR TITLE
修复了clashtun on/off导致的终端显示异常

### DIFF
--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -316,6 +316,8 @@ _tunstatus() {
 _tunoff() {
     _tunstatus >/dev/null || return 0
     sudo placeholder_stop
+    # 强制恢复终端输出处理
+    stty opost 2>/dev/null
     clashstatus >&/dev/null || {
         "$BIN_YQ" -i '.tun.enable = false' "$CLASH_CONFIG_MIXIN"
         _merge_config
@@ -329,6 +331,8 @@ _sudo_restart() {
     sudo placeholder_stop
     placeholder_sudo_start
     sleep 0.5
+    # 强制恢复终端输出处理
+    stty opost 2>/dev/null
 }
 _tunon() {
     _tunstatus 2>/dev/null && return 0
@@ -337,6 +341,9 @@ _tunon() {
     _merge_config
     placeholder_sudo_start
     sleep 0.5
+    # 强制恢复终端输出处理
+    stty opost 2>/dev/null
+
     clashstatus >&/dev/null || _error_quit "Tun 模式开启失败"
     local fail_msg="Start TUN listening error|unsupported kernel version"
     local ok_msg="Tun adapter listening at|TUN listening iface"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -288,8 +288,10 @@ _nohup() {
     service_enable=(false)
     service_disable=(false)
 
-    service_start=('(' nohup "$BIN_KERNEL" -d "$CLASH_RESOURCES_DIR" -f "$CLASH_CONFIG_RUNTIME" '>\&' "$FILE_LOG" '\&' ')')
-    service_sudo_start=(sudo nohup "$BIN_KERNEL" -d "$CLASH_RESOURCES_DIR" -f "$CLASH_CONFIG_RUNTIME" '>\&' "$FILE_LOG" '\&')
+    # 使用子 shell 启动，确保进程脱离终端
+    service_start=('(' nohup "$BIN_KERNEL" -d "$CLASH_RESOURCES_DIR" -f "$CLASH_CONFIG_RUNTIME" '>' "$FILE_LOG" '2>\&1' '\&' ')')
+    # sudo 启动：nohup 完全脱离终端，关闭所有标准流
+    service_sudo_start=(sudo sh -c '"nohup' "$BIN_KERNEL" -d "$CLASH_RESOURCES_DIR" -f "$CLASH_CONFIG_RUNTIME" '<' '/dev/null' '>' "$FILE_LOG" '2>\&1' '\&"')
     service_status=(pgrep -fa "$BIN_KERNEL")
     service_is_active=(pgrep -fa "$BIN_KERNEL")
     service_stop=(pkill -9 -f "$BIN_KERNEL")


### PR DESCRIPTION
如#474issues以及其他一些已关闭的issues提到的，clashtun on/off会导致换行的异常以及%的显示

经过排查，我发现原因是因为 sudo 执行过程中终端的 OPOST 标志被禁用，导致换行符不被转换为回车+换行

我的解决方案是在 _tunon、_tunoff、_sudo_restart 函数中添加 stty opost 恢复终端设置，并且优化 _nohup 函数，确保进程完全脱离终端
