### PR TITLE
fix: add proxy DNS defaults for tun fake-ip mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ $ clashtun on
 
 - 作用：实现本机及 `Docker` 等容器的所有流量路由到 `clash` 代理、DNS 劫持等。
 - 原理：[clash-verge-rev](https://www.clashverge.dev/guide/term.html#tun)、 [clash.wiki](https://clash.wiki/premium/tun-device.html)。
+- 若订阅中的节点 `server` 使用域名，开启 `Tun` + `fake-ip` 后建议为代理节点单独配置 `proxy-server-nameserver`，必要时再配合 `fake-ip-filter`，以避免节点域名被解析为 fake-ip 后导致代理握手失败。
 - 注意事项：[#100](https://github.com/nelvko/clash-for-linux-install/issues/100#issuecomment-2782680205)
 
 ## 🗑️ 卸载

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $ clashtun on
 
 - 作用：实现本机及 `Docker` 等容器的所有流量路由到 `clash` 代理、DNS 劫持等。
 - 原理：[clash-verge-rev](https://www.clashverge.dev/guide/term.html#tun)、 [clash.wiki](https://clash.wiki/premium/tun-device.html)。
-- 若订阅中的节点 `server` 使用域名，开启 `Tun` + `fake-ip` 后建议为代理节点单独配置 `proxy-server-nameserver`，必要时再配合 `fake-ip-filter`，以避免节点域名被解析为 fake-ip 后导致代理握手失败。
+- 若订阅中的节点 `server` 使用域名，默认 `mixin.yaml` 已预置 `proxy-server-nameserver`，可避免开启 `Tun` + `fake-ip` 后节点域名被解析为 fake-ip 而导致代理握手失败；如使用自定义 DNS 配置，建议保留该项，并在必要时再配合 `fake-ip-filter`。
 - 注意事项：[#100](https://github.com/nelvko/clash-for-linux-install/issues/100#issuecomment-2782680205)
 
 ## 🗑️ 卸载

--- a/resources/mixin.yaml
+++ b/resources/mixin.yaml
@@ -56,6 +56,15 @@ dns:
   enable: true
   listen: 0.0.0.0:1053
   enhanced-mode: fake-ip
+  default-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+  # Avoid resolving proxy server domains to fake-ip when Tun + dns-hijack is enabled.
+  proxy-server-nameserver:
+    - 223.5.5.5
+    - 119.29.29.29
+    - 1.1.1.1
+    - 8.8.8.8
   nameserver:
     - 114.114.114.114
     - 8.8.8.8

--- a/resources/mixin.yaml
+++ b/resources/mixin.yaml
@@ -59,7 +59,7 @@ dns:
   default-nameserver:
     - 223.5.5.5
     - 119.29.29.29
-  # Avoid resolving proxy server domains to fake-ip when Tun + dns-hijack is enabled.
+  # 避免在启用 Tun + dns-hijack 时将代理节点域名解析为 fake-ip。
   proxy-server-nameserver:
     - 223.5.5.5
     - 119.29.29.29


### PR DESCRIPTION
## Summary

  This PR makes the default DNS mixin safer for `Tun + fake-ip` setups.

  Changes included in this PR:

  - add `default-nameserver` to the default DNS mixin
  - add `proxy-server-nameserver` to the default DNS mixin
  - document the related behavior in the README `Tun` section

  ## Motivation

  When `Tun` is enabled together with `dns-hijack` and `enhanced-mode: fake-ip`, subscriptions that use domain names in proxy `server` fields can fail if proxy server domains are resolved through the
  fake-ip path.

  In that case, the proxy server domain may be mapped to a fake IP instead of being resolved via a real upstream DNS server, which can lead to failed outbound handshakes and make valid nodes appear
  unusable.

  Adding `proxy-server-nameserver` gives Mihomo a dedicated real-DNS path for resolving proxy node domains and makes the default mixin more reliable.

  ## Scope

  This change is protocol-agnostic.

  It is not specific to `AnyTLS`; any proxy type that uses a domain name in the `server` field may be affected under `Tun + fake-ip`.

  This PR only adds safer defaults and documentation.

  It does not add any provider-specific `fake-ip-filter` rules.

  ## Files changed

  - `resources/mixin.yaml`
  - `README.md`

  ## Notes

  The goal here is to improve the out-of-the-box behavior for users who enable `Tun` and use subscriptions with domain-based proxy nodes, while keeping the change minimal and generic.
