### PR TITLE
fix: fish下参数解析问题

### DIFF
--- a/scripts/cmd/clashctl.fish
+++ b/scripts/cmd/clashctl.fish
@@ -21,24 +21,41 @@ end
 
 
 function clashctl
-    if test -z "$argv"
+    if test (count $argv) -eq 0
         clashhelp
         return
     end
 
-
     set suffix $argv[1]
-    set argv $argv[2..-1]
+    set rest $argv[2..-1]
 
     switch $suffix
         case on
-            clashon $argv
+            clashon $rest
         case off
-            clashoff $argv
+            clashoff $rest
+        case ui
+            clashui $rest
+        case status
+            clashstatus $rest
+        case log
+            clashlog $rest
         case proxy
-            clashproxy $argv
+            clashproxy $rest
+        case tun
+            clashtun $rest
+        case mixin
+            clashmixin $rest
+        case secret
+            clashsecret $rest
+        case sub
+            clashsub $rest
+        case upgrade
+            clashupgrade $rest
+        case -h --help
+            clashhelp
         case '*'
-            clash"$suffix" $argv
+            clashhelp
     end
 end
 


### PR DESCRIPTION
## 变更说明

修复 `fish` 环境下 `clashctl` 的参数分发问题。

当前 `scripts/cmd/clashctl.fish` 中，`clashctl` 会把第一个参数直接拼接成
`clash"$suffix"`，这会导致参数解析失败。在我的使用中，`clashctl --help` 被错误解析成 `clash--help`，显示错误

## 修改内容
- 补齐 `fish` 包装层中对各个子命令的显式分发
- 增加 `-h` / `--help` 的处理
- 让 `fish` 下的行为与 `bash` 版本保持一致

## 复现方式
修复前：
```fish
clashctl --help
clashctl -h
clashctl foo
```
会报类似下面的错误：

fish: 未知的命令：clash--help

## 备注

这个问题我是在本机 fish 环境中复现并验证的，修复后已确认相关命令行为正常。第一次提交pr, 如果提交有问题就和我说说吧