### PR TITLE
为TUN模式状态检查添加核心的状态检查

### DIFF
--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -318,15 +318,18 @@ EOF
 }
 
 _tunstatus() {
-    local tun_status=$("$BIN_YQ" '.tun.enable' "${CLASH_CONFIG_RUNTIME}")
-    case $tun_status in
-    true)
-        _okcat 'Tun 状态：启用'
-        ;;
-    *)
+    if ! clashstatus >&/dev/null; then
         _failcat 'Tun 状态：关闭'
-        ;;
-    esac
+        return 1
+    fi
+    local tun_config=$("$BIN_YQ" '.tun.enable' "${CLASH_CONFIG_RUNTIME}")
+    if [ "$tun_config" = 'true' ]; then
+        _okcat 'Tun 状态：启用'
+        return 0
+    else
+        _failcat 'Tun 状态：关闭'
+        return 1
+    fi
 }
 _tunoff() {
     _tunstatus >/dev/null || return 0


### PR DESCRIPTION
为TUN模式状态检查添加核心的状态检查，确保获取真实的核心状态。因为在nohup模式下，并不会开机自启，所以只检查配置文件里的tun状态并不真实。参考：[ISSUE#524](https://github.com/nelvko/clash-for-linux-install/issues/524)