### PR TITLE
feat: add macOS support

### DIFF
--- a/.env.install
+++ b/.env.install
@@ -5,7 +5,7 @@
 ######################################
 
 # 安装路径
-CLASHCTL_HOME=~/clashctl
+CLASHCTL_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/clashctl"
 
 # 安装内核 
 # 可选：mihomo、clash
@@ -23,10 +23,10 @@ GH_PROXY=https://gh-proxy.org
 
 # 依赖版本
 # 留空：通过 api.github.com 自动获取最新版本号
-# 若网络受限请填写固定版本，例：v0.9.0
-VERSION_MIHOMO= # v1.19.25
-VERSION_YQ= # v4.53.2
-VERSION_SUBCONVERTER= # v0.9.0
+# 若网络受限，建议填写固定版本
+VERSION_MIHOMO=v1.19.27
+VERSION_YQ=v4.53.3
+VERSION_SUBCONVERTER=v0.9.0
 
 # Web UI 压缩包
 ZIP_UI=archives/dist.zip

--- a/MACOS_MIGRATION.md
+++ b/MACOS_MIGRATION.md
@@ -1,0 +1,452 @@
+# macOS Migration Plan
+
+本文档列出将当前项目从 Linux 支持扩展到 macOS 所需的改造内容。
+
+## 目标
+
+让项目在 macOS 上完成以下能力：
+
+- 安装 `mihomo` 内核。
+- 安装 `yq`、Web UI、订阅资源。
+- 可通过 `clashctl` 管理启动、停止、状态、日志、订阅、面板、密钥等功能。
+- 支持 bash、zsh、fish shell 集成。
+- 可选支持 TUN 模式。
+
+## 1. 增加系统识别
+
+当前脚本主要按 Linux 环境假设运行，需要增加 OS 判断。
+
+建议新增公共变量：
+
+```bash
+CLASHCTL_OS="$(uname -s)"
+CLASHCTL_ARCH="$(uname -m)"
+```
+
+需要识别：
+
+- `Linux`
+- `Darwin`
+
+相关文件：
+
+- `scripts/preflight.sh`
+- `scripts/lib/common.sh`
+- `scripts/lib/service.sh`
+
+## 2. 适配 macOS 二进制下载
+
+当前 `download_zip()` 使用 Linux 下载地址。
+
+macOS 需要按 `Darwin + arch` 选择对应包。
+
+### mihomo
+
+需要支持：
+
+- Intel Mac: `mihomo-darwin-amd64`
+- Apple Silicon: `mihomo-darwin-arm64`
+
+### yq
+
+需要支持：
+
+- Intel Mac: `yq_darwin_amd64.tar.gz`
+- Apple Silicon: `yq_darwin_arm64.tar.gz`
+
+### subconverter
+
+优先继续使用 `subconverter` 的 macOS 构建。
+
+需要支持：
+
+- Intel Mac: `subconverter_darwin64.tar.gz`
+- Apple Silicon: 如果上游没有稳定 arm64 包，需要：
+  - 使用 x86_64 包配合 Rosetta。
+  - 或禁用本地订阅转换。
+  - 或改为接入其他订阅转换方案。
+
+相关文件：
+
+- `scripts/preflight.sh`
+
+## 3. 替换 Linux 专用命令
+
+当前部分命令只适用于 Linux，macOS 需要替换。
+
+| 当前用法 | Linux 命令 | macOS 替代 |
+|---|---|---|
+| 服务识别 | `/proc/1/exe`、`/proc/1/cgroup` | `uname -s`，macOS 固定走 `launchd` 或 `nohup` |
+| CPU 特性 | `/proc/cpuinfo` | macOS 不需要 x86-64-v2/v3 判断，直接选 darwin 包 |
+| 端口检测 | `ss` / `netstat -tunlp` | `lsof -nP -iTCP -iUDP` 或 `netstat -an` |
+| 本机 IP | `ip route` / `hostname -I` | `route get 1.1.1.1` + `ipconfig getifaddr` |
+| TUN 状态 | `ip link show` | `ifconfig` |
+| 随机端口 | `shuf` | `jot -r 1 1024 65535` 或 bash `$RANDOM` |
+| sed 原地修改 | GNU `sed -i` | BSD `sed -i ''` |
+
+相关文件：
+
+- `scripts/lib/common.sh`
+- `scripts/lib/config.sh`
+- `scripts/lib/service.sh`
+- `scripts/preflight.sh`
+
+## 4. 增加 launchd 服务支持
+
+macOS 不使用 systemd/openrc/runit/sysvinit，需要新增 `launchd`。
+
+### 新增模板
+
+新增文件：
+
+- `scripts/init/launchd.plist`
+
+建议模板内容包含：
+
+- `Label`
+- `ProgramArguments`
+- `WorkingDirectory`
+- `StandardOutPath`
+- `StandardErrorPath`
+- `RunAtLoad`
+- `KeepAlive`
+
+### 用户级服务
+
+普通用户安装建议写入：
+
+```text
+~/Library/LaunchAgents/com.clashctl.mihomo.plist
+```
+
+使用命令：
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.clashctl.mihomo.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.clashctl.mihomo.plist
+launchctl kickstart -k gui/$(id -u)/com.clashctl.mihomo
+launchctl print gui/$(id -u)/com.clashctl.mihomo
+```
+
+### 系统级服务
+
+如果要支持 TUN 或开机全局运行，可写入：
+
+```text
+/Library/LaunchDaemons/com.clashctl.mihomo.plist
+```
+
+系统级服务通常需要 root 权限。
+
+相关文件：
+
+- `scripts/lib/service.sh`
+- `scripts/init/launchd.plist`
+
+## 5. 改造 service.sh
+
+需要在 `detect_service_manager()` 中加入 macOS 分支：
+
+```bash
+if [ "$(uname -s)" = "Darwin" ]; then
+    service_manager="launchd"
+fi
+```
+
+需要新增这些分支：
+
+- `service_start()`
+- `service_stop()`
+- `service_restart()`
+- `service_status()`
+- `service_is_active()`
+- `service_log()`
+- `service_follow_log()`
+- `service_read_log()`
+- `install_service()`
+- `uninstall_service()`
+
+日志路径建议：
+
+```text
+$CLASH_RESOURCES_DIR/mihomo.log
+```
+
+或：
+
+```text
+~/Library/Logs/clashctl/mihomo.log
+```
+
+## 6. 适配 shell rc 写入
+
+当前 bash、zsh、fish 都已有基础支持。
+
+macOS 需要注意：
+
+- 默认 shell 通常是 zsh。
+- `~/.bashrc` 不一定存在。
+- zsh 交互环境通常读 `~/.zshrc`。
+- fish 继续写入 `~/.config/fish/conf.d/clashctl.fish`。
+
+建议保持现有逻辑，只修复 macOS 上 `sed -i` 的兼容问题。
+
+相关文件：
+
+- `scripts/preflight.sh`
+
+## 7. 适配端口检测
+
+当前 `_is_port_used()` 依赖：
+
+```bash
+ss -tunlp
+netstat -tunlp
+```
+
+macOS 建议改为：
+
+```bash
+lsof -nP -iTCP:"$1" -iUDP:"$1" 2>/dev/null | grep -q .
+```
+
+或：
+
+```bash
+netstat -an | grep -q "[.:]$1 "
+```
+
+相关文件：
+
+- `scripts/lib/common.sh`
+
+## 8. 适配本机 IP 获取
+
+当前 `_get_local_ip()` 使用 Linux 命令。
+
+macOS 可改为：
+
+```bash
+iface=$(route get 1.1.1.1 2>/dev/null | awk '/interface:/{print $2}')
+ipconfig getifaddr "$iface"
+```
+
+相关文件：
+
+- `scripts/lib/common.sh`
+
+## 9. 适配随机端口生成
+
+当前 `_get_random_port()` 使用 `shuf`。
+
+macOS 默认没有 `shuf`。
+
+可替换为：
+
+```bash
+jot -r 1 1024 65535
+```
+
+或者用 bash：
+
+```bash
+echo $((RANDOM % 64512 + 1024))
+```
+
+相关文件：
+
+- `scripts/lib/common.sh`
+
+## 10. 适配 TUN 模式
+
+当前 `tunstatus()` 使用：
+
+```bash
+ip link show
+```
+
+macOS 应改为：
+
+```bash
+ifconfig | grep -q "$device"
+```
+
+注意：
+
+- macOS TUN 通常需要更高权限。
+- `launchd` 用户级服务可能无法正常启用 TUN。
+- TUN 模式建议走系统级 LaunchDaemon 或提示用户使用 sudo。
+
+相关文件：
+
+- `scripts/lib/config.sh`
+- `scripts/cmd/tun.sh`
+- `scripts/lib/service.sh`
+
+## 11. 适配 sed
+
+当前多处使用：
+
+```bash
+sed -i
+```
+
+macOS BSD sed 需要：
+
+```bash
+sed -i ''
+```
+
+建议封装公共函数：
+
+```bash
+_sed_inplace() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+```
+
+然后替换项目中的原地修改调用。
+
+相关文件：
+
+- `scripts/lib/common.sh`
+- `scripts/lib/service.sh`
+- `scripts/preflight.sh`
+
+## 12. 调整依赖检查
+
+当前 `valid_required()` 要求：
+
+- `xz`
+- `pgrep`
+- `pkill`
+- `curl`
+- `tar`
+- `unzip`
+- `gzip`
+- `shuf`
+- `ss/netstat`
+- `ip/hostname`
+
+macOS 应调整为：
+
+- `pgrep`
+- `pkill`
+- `curl`
+- `tar`
+- `unzip`
+- `gzip`
+- `lsof` 或 `netstat`
+- `route`
+- `ipconfig`
+- `ifconfig`
+- `jot` 或移除对 `jot` 的依赖
+
+相关文件：
+
+- `scripts/preflight.sh`
+
+## 13. 卸载逻辑
+
+`uninstall_service()` 需要支持：
+
+- 停止 launchd 服务。
+- 卸载 launchd plist。
+- 删除日志。
+- 删除 shell rc 注入。
+
+用户级服务路径：
+
+```text
+~/Library/LaunchAgents/com.clashctl.mihomo.plist
+```
+
+系统级服务路径：
+
+```text
+/Library/LaunchDaemons/com.clashctl.mihomo.plist
+```
+
+相关文件：
+
+- `scripts/lib/service.sh`
+- `uninstall.sh`
+
+## 14. 安装路径
+
+当前默认：
+
+```bash
+CLASHCTL_HOME=~/clashctl
+```
+
+macOS 可以继续使用该路径。
+
+可选更符合 macOS 习惯的路径：
+
+```text
+~/.local/share/clashctl
+```
+
+建议先保持原路径，减少改动范围。
+
+相关文件：
+
+- `.env.install`
+
+## 15. 命令兼容性测试
+
+macOS 迁移后至少验证：
+
+- `bash install.sh`
+- `clashctl help`
+- `clashctl status`
+- `clashon`
+- `clashoff`
+- `clashlog`
+- `clashui`
+- `clashsecret`
+- `clashsub add`
+- `clashsub update`
+- `bash uninstall.sh`
+
+shell 验证：
+
+- zsh
+- bash
+- fish
+
+架构验证：
+
+- Intel Mac
+- Apple Silicon Mac
+
+## 16. 推荐实施顺序
+
+1. 增加 OS/arch 判断。
+2. 改造依赖下载地址。
+3. 封装 macOS/Linux 通用命令函数。
+4. 增加 `launchd` 服务模板。
+5. 在 `service.sh` 中加入 `launchd` 分支。
+6. 修复 `sed -i`、端口检测、本机 IP、随机端口。
+7. 适配 TUN 状态检测。
+8. 调整卸载逻辑。
+9. 在 macOS Intel 和 Apple Silicon 上测试。
+10. 更新 README 安装说明。
+
+## 17. 最小可行版本
+
+如果先做最小 macOS 支持，可以暂时只实现：
+
+- `mihomo` macOS 二进制下载。
+- `yq` macOS 二进制下载。
+- `nohup` 模式启动。
+- bash/zsh/fish 命令可用。
+- 禁用或延后 TUN。
+- 禁用或延后 subconverter 的 macOS arm64 适配。
+
+这样可以先让普通代理功能跑起来，再逐步补齐 launchd 和 TUN。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## ✨ Features
 
 - **开箱即用**：一键部署 `mihomo` / `clash` 内核、Web 面板及运行依赖。
-- **广泛兼容**：支持 `root` / 普通用户，适配主流 `Linux` 发行版、容器环境及 `systemd` / `OpenRC` 等 `init` 系统。
+- **广泛兼容**：支持 `root` / 普通用户，适配主流 `Linux` 发行版、容器环境、`systemd` / `OpenRC` 等 `init` 系统，以及 `macOS launchd`。
 - **统一管理**：通过 `clashctl` 管理代理启停、状态查看、日志追踪、Web 面板、TUN 模式、访问密钥与内核升级等。
 - **订阅管理**：支持多订阅源配置、一键切换、定时更新，并集成 [subconverter](https://github.com/tindy2013/subconverter) 实现订阅格式转换。
 
@@ -34,6 +34,7 @@ git clone --branch master --depth 1 https://gh-proxy.org/https://github.com/nelv
 
 - 上述命令使用了[加速前缀](https://gh-proxy.org/)，如失效请更换其他[可用链接](https://ghproxy.link/)。
 - 可通过 `.env.install` 文件自定义安装选项。
+- `macOS` 目前仅支持 `mihomo` 内核。
 - 没有订阅？[click me](https://次元.net/auth/register?code=oUbI)
 
 ## 📖 Documentation

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,11 @@ _okcat '📦' "安装路径：$CLASHCTL_HOME"
 
 prepare_zip
 
-install_service
 install_clashctl
 
 _merge_config
 _detect_proxy_port
+install_service
 clashui
 [ -z "$(_get_secret)" ] && clashsecret "$(_get_random_val)" >/dev/null
 clashsecret

--- a/scripts/cmd/sub.sh
+++ b/scripts/cmd/sub.sh
@@ -139,7 +139,7 @@ _sub_del() {
     use=$("$BIN_YQ" '.use // "" | tostring' "$CLASH_PROFILES_META")
     [ "$use" = "$id" ] && { _errorcat "删除失败：订阅 $id 正在使用中，请先切换订阅"; return 1; }
 
-    /usr/bin/rm -f "$profile_path"
+    rm -f "$profile_path"
     PROFILE_ID=$id "$BIN_YQ" -i 'del(.profiles[] | select((.id | tostring) == env(PROFILE_ID)))' "$CLASH_PROFILES_META"
     _logging_sub "➖ 已删除订阅：[$id] $url"
     _okcat '🎉' "订阅已删除：[$id] $url"

--- a/scripts/init/launchd.plist
+++ b/scripts/init/launchd.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>placeholder_launchd_label</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>placeholder_cmd_path</string>
+    <string>-d</string>
+    <string>placeholder_work_dir</string>
+    <string>-f</string>
+    <string>placeholder_config_path</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>placeholder_work_dir</string>
+
+  <key>StandardOutPath</key>
+  <string>placeholder_log_path</string>
+
+  <key>StandardErrorPath</key>
+  <string>placeholder_log_path</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <false/>
+</dict>
+</plist>

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -21,7 +21,15 @@ CLASH_PROFILES_LOG="${CLASH_RESOURCES_DIR}/profiles.log"
 
 CLASHCTL_CRON_TAG="# clashctl-auto-update"
 
+_is_macos() {
+    [ "$(uname -s)" = "Darwin" ]
+}
+
 _is_port_used() {
+    if _is_macos; then
+        { lsof -nP -iTCP:"$1" -iUDP:"$1" 2>/dev/null || netstat -an 2>/dev/null; } | grep -qs "[.:]$1[[:space:]]"
+        return
+    fi
     { ss -tunlp 2>/dev/null || netstat -tunlp 2>/dev/null; } | grep -qs "$1"
 }
 
@@ -33,7 +41,13 @@ _get_random_port() {
     local fail_count=0
     while [ "$fail_count" -lt 100 ]; do
         local random_port
-        random_port=$(shuf -i 1024-65535 -n 1)
+        if command -v shuf >&/dev/null; then
+            random_port=$(shuf -i 1024-65535 -n 1)
+        elif command -v jot >&/dev/null; then
+            random_port=$(jot -r 1 1024 65535)
+        else
+            random_port=$((RANDOM % 64512 + 1024))
+        fi
         ! _is_port_used "$random_port" && {
             printf '%s\n' "$random_port"
             return 0
@@ -45,13 +59,19 @@ _get_random_port() {
 
 _get_local_ip() {
     local local_ip
-    local_ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')
-    [ -z "$local_ip" ] && local_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    if _is_macos; then
+        local iface
+        iface=$(route get 1.1.1.1 2>/dev/null | awk '/interface:/{print $2}')
+        [ -n "$iface" ] && local_ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
+    else
+        local_ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}')
+        [ -z "$local_ip" ] && local_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    fi
     printf '%s\n' "$local_ip"
 }
 
 _get_random_val() {
-    tr -dc 'a-zA-Z0-9' </dev/urandom | head -c 6
+    LC_ALL=C tr -dc 'a-zA-Z0-9' </dev/urandom | head -c 6
 }
 
 _color_log() {
@@ -107,8 +127,22 @@ _set_env() {
         value=${value//\\/\\\\}
         value=${value//&/\\&}
         value=${value//|/\\|}
-        sed -i "s|^${key}=.*|${key}=${value}|" "$env_path"
+        _sed_inplace "s|^${key}=.*|${key}=${value}|" "$env_path"
         return $?
     }
     printf '%s=%s\n' "$key" "$value" >>"$env_path"
+}
+
+_sed_inplace() {
+    if _is_macos; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+_install_file() {
+    local mode=$1 src=$2 target=$3
+    /usr/bin/install -d "$(dirname -- "$target")"
+    /usr/bin/install -m "$mode" "$src" "$target"
 }

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -180,7 +180,7 @@ tunstatus() {
   local device
   device=$("$BIN_YQ" '.tun.device // ""' "$CLASH_CONFIG_RUNTIME")
   [ -z "$device" ] && device="Meta"
-  ip link show | grep -qs "$device" && {
+  { if _is_macos; then ifconfig; else ip link show; fi; } 2>/dev/null | grep -qs "$device" && {
     _okcat 'Tun 状态：启用'
     return 0
   }

--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -3,9 +3,31 @@
 service_manager=
 service_log_path=
 service_pid_path=
+service_launchd_label=
+service_launchd_domain=
+service_launchd_plist=
+
+_launchd_setup() {
+    service_launchd_label="com.clashctl.${CLASHCTL_KERNEL}"
+    if _is_root; then
+        service_launchd_domain="system"
+        service_launchd_plist="/Library/LaunchDaemons/${service_launchd_label}.plist"
+    else
+        service_launchd_domain="gui/$(id -u)"
+        service_launchd_plist="${HOME}/Library/LaunchAgents/${service_launchd_label}.plist"
+    fi
+}
 
 detect_service_manager() {
     [ -n "$service_manager" ] && return 0
+    if _is_macos; then
+        service_manager="launchd"
+        service_log_path="${CLASH_RESOURCES_DIR}/${CLASHCTL_KERNEL}.log"
+        service_pid_path="${CLASH_RESOURCES_DIR}/${CLASHCTL_KERNEL}.pid"
+        _launchd_setup
+        return 0
+    fi
+
     [ -z "$INIT_TYPE" ] && INIT_TYPE=$(readlink /proc/1/exe 2>/dev/null || echo "nohup")
     grep -qsE "docker|kubepods|containerd|podman|lxc" /proc/1/cgroup 2>/dev/null && INIT_TYPE='nohup'
     _is_root || INIT_TYPE='nohup'
@@ -44,6 +66,10 @@ detect_service_manager() {
 service_start() {
     detect_service_manager
     case "$service_manager" in
+    launchd)
+        launchctl bootstrap "$service_launchd_domain" "$service_launchd_plist" >/dev/null 2>&1 || true
+        launchctl kickstart -k "${service_launchd_domain}/${service_launchd_label}"
+        ;;
     systemd)
         systemctl start "$CLASHCTL_KERNEL"
         ;;
@@ -84,6 +110,9 @@ service_sudo_stop() {
 service_stop() {
     detect_service_manager
     case "$service_manager" in
+    launchd)
+        launchctl bootout "$service_launchd_domain" "$service_launchd_plist" >/dev/null 2>&1 || true
+        ;;
     systemd)
         systemctl stop "$CLASHCTL_KERNEL"
         ;;
@@ -107,6 +136,10 @@ service_stop() {
 service_restart() {
     detect_service_manager
     case "$service_manager" in
+    launchd)
+        service_stop >/dev/null 2>&1
+        service_start
+        ;;
     systemd)
         systemctl restart "$CLASHCTL_KERNEL"
         ;;
@@ -130,6 +163,9 @@ service_restart() {
 service_status() {
     detect_service_manager
     case "$service_manager" in
+    launchd)
+        launchctl print "${service_launchd_domain}/${service_launchd_label}"
+        ;;
     systemd)
         systemctl status "$CLASHCTL_KERNEL" "$@"
         ;;
@@ -151,6 +187,10 @@ service_status() {
 service_is_active() {
     detect_service_manager
     case "$service_manager" in
+    launchd)
+        launchctl print "${service_launchd_domain}/${service_launchd_label}" 2>/dev/null | grep -qs "state = running" ||
+            pgrep -fa "$BIN_KERNEL" >/dev/null 2>&1
+        ;;
     systemd)
         systemctl is-active "$CLASHCTL_KERNEL" >/dev/null 2>&1
         ;;
@@ -175,6 +215,13 @@ service_log() {
     systemd)
         journalctl -u "$CLASHCTL_KERNEL" "$@"
         ;;
+    launchd)
+        [ $# -gt 0 ] && {
+            tail "$@" "$service_log_path"
+            return
+        }
+        less "$service_log_path"
+        ;;
     *)
         [ $# -gt 0 ] && {
             tail "$@" "$service_log_path"
@@ -191,6 +238,9 @@ service_follow_log() {
     systemd)
         journalctl -u "$CLASHCTL_KERNEL" -q -f -n 0
         ;;
+    launchd)
+        tail -f -n 0 "$service_log_path"
+        ;;
     *)
         tail -f -n 0 "$service_log_path"
         ;;
@@ -202,6 +252,9 @@ service_read_log() {
     case "$service_manager" in
     systemd)
         journalctl -u "$CLASHCTL_KERNEL" --no-pager
+        ;;
+    launchd)
+        cat "$service_log_path" 2>/dev/null
         ;;
     *)
         cat "$service_log_path" 2>/dev/null
@@ -220,6 +273,10 @@ install_service() {
     local service_src service_target
 
     case "$service_manager" in
+    launchd)
+        service_src="${template_dir}/launchd.plist"
+        service_target="$service_launchd_plist"
+        ;;
     systemd)
         service_src="${template_dir}/systemd.sh"
         service_target="/etc/systemd/system/${CLASHCTL_KERNEL}.service"
@@ -241,8 +298,8 @@ install_service() {
         ;;
     esac
 
-    /usr/bin/install -D -m +x "$service_src" "$service_target"
-    sed -i \
+    _install_file 0755 "$service_src" "$service_target"
+    _sed_inplace \
         -e "s#placeholder_cmd_path#$cmd_path#g" \
         -e "s#placeholder_cmd_args#$cmd_arg#g" \
         -e "s#placeholder_cmd_full#$cmd_full#g" \
@@ -250,9 +307,21 @@ install_service() {
         -e "s#placeholder_pid_path#$service_pid_path#g" \
         -e "s#placeholder_kernel_name#$CLASHCTL_KERNEL#g" \
         -e "s#placeholder_kernel_desc#$kernel_desc#g" \
+        -e "s#placeholder_launchd_label#$service_launchd_label#g" \
+        -e "s#placeholder_work_dir#$CLASH_RESOURCES_DIR#g" \
+        -e "s#placeholder_config_path#$CLASH_CONFIG_RUNTIME#g" \
         "$service_target"
 
     case "$service_manager" in
+    launchd)
+        launchctl bootout "$service_launchd_domain" "$service_target" >/dev/null 2>&1 || true
+        launchctl bootstrap "$service_launchd_domain" "$service_target" || {
+            _failcat '❌' '注册 launchd 服务失败'
+            exit 1
+        }
+        _okcat '🧩' "已注册 launchd 服务：$service_launchd_label"
+        _okcat '🚀' '已设置开机自启'
+        ;;
     systemd)
         systemctl daemon-reload || {
             _failcat '❌' '重载 systemd 配置失败'
@@ -340,9 +409,17 @@ uninstall_service() {
     detect_service_manager
     service_stop >&/dev/null
     case "$service_manager" in
+    launchd)
+        launchctl bootout "$service_launchd_domain" "$service_launchd_plist" >/dev/null 2>&1 || true
+        rm -f -- "$service_launchd_plist" || {
+            _failcat '❌' '移除 launchd 服务失败'
+            return 1
+        }
+        _okcat '🧹' "已注销 launchd 服务：$service_launchd_label"
+        ;;
     systemd)
         systemctl disable "$CLASHCTL_KERNEL" >&/dev/null
-        /usr/bin/rm -f -- "/etc/systemd/system/${CLASHCTL_KERNEL}.service" || {
+        rm -f -- "/etc/systemd/system/${CLASHCTL_KERNEL}.service" || {
             _failcat '❌' '移除 systemd 服务失败'
             return 1
         }
@@ -361,15 +438,15 @@ uninstall_service() {
         elif command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d "$CLASHCTL_KERNEL" remove >/dev/null 2>&1 || true
         fi
-        /usr/bin/rm -f "/etc/init.d/${CLASHCTL_KERNEL}"
+        rm -f "/etc/init.d/${CLASHCTL_KERNEL}"
         ;;
     openrc)
         rc-update del "$CLASHCTL_KERNEL" default >/dev/null 2>&1 || true
-        /usr/bin/rm -f "/etc/init.d/${CLASHCTL_KERNEL}"
+        rm -f "/etc/init.d/${CLASHCTL_KERNEL}"
         ;;
     runit)
-        /usr/bin/rm -f "/etc/runit/runsvdir/default/${CLASHCTL_KERNEL}"
-        /usr/bin/rm -rf "/etc/sv/${CLASHCTL_KERNEL}"
+        rm -f "/etc/runit/runsvdir/default/${CLASHCTL_KERNEL}"
+        rm -rf "/etc/sv/${CLASHCTL_KERNEL}"
         ;;
     nohup | *)
         return 0

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -14,14 +14,22 @@ ZIP_BASE_DIR="${ARCHIVE_BASE_DIR}"
 CLASHCTL_CMD_DIR="${CLASHCTL_HOME}/scripts/cmd"
 
 valid_required() {
-    local required_cmds=("xz" "pgrep" "pkill" "curl" "tar" 'unzip' 'gzip' 'shuf')
+    local required_cmds=("pgrep" "pkill" "curl" "tar" 'unzip' 'gzip')
     local missing=()
     for cmd in "${required_cmds[@]}"; do
         command -v "$cmd" >&/dev/null || missing+=("$cmd")
     done
 
-    command -v ss >&/dev/null || command -v netstat >&/dev/null || missing+=("ss/netstat")
-    command -v ip >&/dev/null || command -v hostname >&/dev/null || missing+=("ip/hostname")
+    if _is_macos; then
+        command -v lsof >&/dev/null || command -v netstat >&/dev/null || missing+=("lsof/netstat")
+        command -v route >&/dev/null || missing+=("route")
+        command -v ipconfig >&/dev/null || missing+=("ipconfig")
+        command -v ifconfig >&/dev/null || missing+=("ifconfig")
+    else
+        command -v shuf >&/dev/null || missing+=("shuf")
+        command -v ss >&/dev/null || command -v netstat >&/dev/null || missing+=("ss/netstat")
+        command -v ip >&/dev/null || command -v hostname >&/dev/null || missing+=("ip/hostname")
+    fi
 
     [ ${#missing[@]} -eq 0 ] || _errorcat "请先安装以下命令：${missing[*]}" || exit
 }
@@ -56,6 +64,11 @@ parse_args() {
 }
 
 prepare_zip() {
+    _is_macos && [ "$CLASHCTL_KERNEL" = "clash" ] && {
+        _errorcat "macOS 暂不支持 clash 内核，请使用 mihomo"
+        exit 1
+    }
+
     load_zip >&/dev/null
     local required_zips=()
     case "${CLASHCTL_KERNEL}" in
@@ -85,14 +98,36 @@ prepare_zip() {
 load_zip() {
     local matches=()
     shopt -s nullglob
-    matches=("${ZIP_BASE_DIR}"/clash*)
-    ZIP_CLASH="${matches[0]:-}"
-    matches=("${ZIP_BASE_DIR}"/mihomo*)
-    ZIP_MIHOMO="${matches[0]:-}"
-    matches=("${ZIP_BASE_DIR}"/yq*)
-    ZIP_YQ="${matches[0]:-}"
-    matches=("${ZIP_BASE_DIR}"/subconverter*)
-    ZIP_SUBCONVERTER="${matches[0]:-}"
+    if _is_macos; then
+        ZIP_CLASH=
+        case "$(uname -m)" in
+        x86_64)
+            matches=("${ZIP_BASE_DIR}"/mihomo-darwin-amd64-*.gz)
+            ZIP_MIHOMO="${matches[0]:-}"
+            matches=("${ZIP_BASE_DIR}"/yq_darwin_amd64.tar.gz)
+            ZIP_YQ="${matches[0]:-}"
+            matches=("${ZIP_BASE_DIR}"/subconverter_darwin64.tar.gz)
+            ZIP_SUBCONVERTER="${matches[0]:-}"
+            ;;
+        arm64 | aarch64)
+            matches=("${ZIP_BASE_DIR}"/mihomo-darwin-arm64-*.gz)
+            ZIP_MIHOMO="${matches[0]:-}"
+            matches=("${ZIP_BASE_DIR}"/yq_darwin_arm64.tar.gz)
+            ZIP_YQ="${matches[0]:-}"
+            matches=("${ZIP_BASE_DIR}"/subconverter_darwinarm.tar.gz)
+            ZIP_SUBCONVERTER="${matches[0]:-}"
+            ;;
+        esac
+    else
+        matches=("${ZIP_BASE_DIR}"/clash*)
+        ZIP_CLASH="${matches[0]:-}"
+        matches=("${ZIP_BASE_DIR}"/mihomo*)
+        ZIP_MIHOMO="${matches[0]:-}"
+        matches=("${ZIP_BASE_DIR}"/yq*)
+        ZIP_YQ="${matches[0]:-}"
+        matches=("${ZIP_BASE_DIR}"/subconverter*)
+        ZIP_SUBCONVERTER="${matches[0]:-}"
+    fi
     shopt -u nullglob
 }
 _fetch_latest_tag() {
@@ -122,7 +157,9 @@ _resolve_version() {
 download_zip() {
     (($#)) || return 0
     local url_clash url_mihomo url_yq url_subconverter
-    local arch=$(uname -m)
+    local os arch
+    os=$(uname -s)
+    arch=$(uname -m)
 
     _okcat '🔎' "查询依赖最新版本..."
     local item
@@ -134,53 +171,72 @@ download_zip() {
         esac
     done
 
-    case "$arch" in
-    x86_64)
-        local flags=$(grep -m1 '^flags' /proc/cpuinfo)
-        local level=v1
-        grep -qw sse4_2 <<<"$flags" && grep -qw popcnt <<<"$flags" && level=v2
-        grep -qw avx2 <<<"$flags" && grep -qw fma <<<"$flags" && level=v3
-        VERSION_MIHOMO=${level}-$VERSION_MIHOMO
+    if [ "$os" = "Darwin" ]; then
+        case "$arch" in
+        x86_64)
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO}/mihomo-darwin-amd64-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_darwin_amd64.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_darwin64.tar.gz
+            ;;
+        arm64 | aarch64)
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO}/mihomo-darwin-arm64-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_darwin_arm64.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_darwinarm.tar.gz
+            ;;
+        *)
+            _errorcat "未知的 macOS 架构版本：$arch，请自行下载对应版本至 ${ZIP_BASE_DIR} 目录" || exit
+            ;;
+        esac
+    else
+        case "$arch" in
+        x86_64)
+            local flags level
+            flags=$(grep -m1 '^flags' /proc/cpuinfo)
+            level=v1
+            grep -qw sse4_2 <<<"$flags" && grep -qw popcnt <<<"$flags" && level=v2
+            grep -qw avx2 <<<"$flags" && grep -qw fma <<<"$flags" && level=v3
+            VERSION_MIHOMO=${level}-$VERSION_MIHOMO
 
-        url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-amd64-2023.08.17.gz
-        url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-amd64-${VERSION_MIHOMO}.gz
-        url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_amd64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
-        ;;
-    *86*)
-        url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-386-2023.08.17.gz
-        url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-386-${VERSION_MIHOMO}.gz
-        url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_386.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
-        ;;
-    armv*)
-        url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-armv5-2023.08.17.gz
-        url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-armv7-${VERSION_MIHOMO}.gz
-        url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
-        ;;
-    aarch64)
-        url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-arm64-2023.08.17.gz
-        url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-arm64-${VERSION_MIHOMO}.gz
-        url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
-        ;;
-    *)
-        _errorcat "未知的架构版本：$arch，请自行下载对应版本至 ${ZIP_BASE_DIR} 目录" || exit
-        ;;
-    esac
+            url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-amd64-2023.08.17.gz
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-amd64-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_amd64.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
+            ;;
+        *86*)
+            url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-386-2023.08.17.gz
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-386-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_386.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
+            ;;
+        armv*)
+            url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-armv5-2023.08.17.gz
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-armv7-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
+            ;;
+        aarch64)
+            url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-arm64-2023.08.17.gz
+            url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-arm64-${VERSION_MIHOMO}.gz
+            url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm64.tar.gz
+            url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
+            ;;
+        *)
+            _errorcat "未知的架构版本：$arch，请自行下载对应版本至 ${ZIP_BASE_DIR} 目录" || exit
+            ;;
+        esac
+    fi
 
-    local -A urls=(
-        [clash]="$url_clash"
-        [mihomo]="$url_mihomo"
-        [yq]="$url_yq"
-        [subconverter]="$url_subconverter"
-    )
-
-    local item target_zips=() level=
-    _okcat '🖥️ ' "系统架构：$arch $level"
+    local item target_zips=() url=
+    _okcat '🖥️ ' "系统架构：$os $arch"
     for item in "$@"; do
-        local url="${urls[$item]}"
+        case $item in
+        clash) url=$url_clash ;;
+        mihomo) url=$url_mihomo ;;
+        yq) url=$url_yq ;;
+        subconverter) url=$url_subconverter ;;
+        esac
+        [ -n "$url" ] || _errorcat "未找到 ${item} 对应下载地址" || exit
+
         local proxy_url="${GH_PROXY:+${GH_PROXY%/}/}${url}"
         url="$proxy_url"
         _okcat '⏳' "正在下载：${item}：$url"
@@ -211,10 +267,14 @@ valid_zip() {
 }
 unzip_zip() {
     valid_zip "$ZIP_KERNEL" "$ZIP_YQ" "$ZIP_SUBCONVERTER" "$ZIP_UI"
-    /usr/bin/install -D <(gzip -dc "$ZIP_KERNEL") "$BIN_KERNEL"
+    /usr/bin/install -d "$BIN_BASE_DIR" "$CLASH_RESOURCES_DIR"
+    gzip -dc "$ZIP_KERNEL" >"$BIN_KERNEL"
+    chmod 0755 "$BIN_KERNEL"
     tar -xf "$ZIP_YQ" -C "${BIN_BASE_DIR}"
     /bin/mv -f "${BIN_BASE_DIR}"/yq_* "${BIN_BASE_DIR}/yq"
+    chmod 0755 "${BIN_BASE_DIR}/yq"
     tar -xf "$ZIP_SUBCONVERTER" -C "$BIN_BASE_DIR"
+    chmod 0755 "$BIN_SUBCONVERTER" 2>/dev/null || true
     /bin/cp "$BIN_SUBCONVERTER_DIR/pref.example.yml" "$BIN_SUBCONVERTER_CONFIG"
     unzip -oqq "$ZIP_UI" -d "$CLASH_RESOURCES_DIR" 2>/dev/null || tar -xf "$ZIP_UI" -C "$CLASH_RESOURCES_DIR"
 }
@@ -304,7 +364,7 @@ revoke_rc() {
     local rc
     for rc in "$SHELL_RC_BASH" "$SHELL_RC_ZSH"; do
         [ ! -f "$rc" ] && continue
-        sed -i.bak --follow-symlinks '/CLASHCTL_HOME/d' "$rc" 2>/dev/null
+        _sed_inplace '/CLASHCTL_HOME/d' "$rc" 2>/dev/null
     done
 
     [ -n "$SHELL_RC_FISH" ] && rm -f -- "$SHELL_RC_FISH" 2>/dev/null

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,7 +14,7 @@ command -v crontab >&/dev/null && {
     crontab -l 2>/dev/null | grep -Fv "$CLASHCTL_CRON_TAG" | crontab -
 }
 
-/usr/bin/rm -rf "$CLASHCTL_HOME"
+rm -rf "$CLASHCTL_HOME"
 revoke_rc
 
 _okcat '✨' "已卸载，相关配置已清除"


### PR DESCRIPTION
## Summary

  Add initial macOS support for `clashctl`.

  ## Changes

  - Add Darwin/macOS binary download support for:
    - `mihomo`
    - `yq`
    - `subconverter`
  - Add `launchd` service support via a new plist template.
  - Support macOS-compatible command handling for:
    - port detection
    - local IP detection
    - random port generation
    - `sed -i`
    - `rm`
    - `tr` with `/dev/urandom`
    - TUN status detection
  - Update install flow so resources/config are prepared before service registration/startup.
  - Update README to document macOS support.

  ## Notes

  - macOS currently supports `mihomo` only.
  - `clash` kernel remains Linux-only.
  - TUN mode on macOS may require elevated permissions.

  ## Validation

  - Ran shell syntax checks with `bash -n`.
  - Validated `launchd` plist with `plutil -lint`.
  - Verified macOS release asset URLs for `mihomo`, `yq`, and `subconverter`.