### PR TITLE
feat(subconverter): switch subconverter to asdlokj1qpi233 fork

### DIFF
--- a/scripts/lib/convert.sh
+++ b/scripts/lib/convert.sh
@@ -61,7 +61,14 @@ _download_convert_config() {
             --write-out '%{url_effective}' \
             "$base_url"
     )
-    curl --user-agent "$CLASHCTL_SUB_UA" --silent --output "$dest" "$convert_url"
+    curl \
+        --user-agent "$CLASHCTL_SUB_UA" \
+        --silent \
+        --show-error \
+        --fail \
+        --max-time "$CLASHCTL_SUB_TIMEOUT" \
+        --output "$dest" \
+        "$convert_url"
     flag=$?
     _stop_convert
     return $flag

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -130,7 +130,7 @@ download_zip() {
         case $item in
         mihomo) _resolve_version VERSION_MIHOMO MetaCubeX/mihomo || exit ;;
         yq) _resolve_version VERSION_YQ mikefarah/yq || exit ;;
-        subconverter) _resolve_version VERSION_SUBCONVERTER tindy2013/subconverter || exit ;;
+        subconverter) _resolve_version VERSION_SUBCONVERTER asdlokj1qpi233/subconverter || exit ;;
         esac
     done
 
@@ -145,25 +145,25 @@ download_zip() {
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-amd64-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-amd64-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_amd64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
+        url_subconverter=https://github.com/asdlokj1qpi233/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
         ;;
     *86*)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-386-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-386-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_386.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
+        url_subconverter=https://github.com/asdlokj1qpi233/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
         ;;
     armv*)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-armv5-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-armv7-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
+        url_subconverter=https://github.com/asdlokj1qpi233/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
         ;;
     aarch64)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-arm64-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-arm64-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
+        url_subconverter=https://github.com/asdlokj1qpi233/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
         ;;
     *)
         _errorcat "未知的架构版本：$arch，请自行下载对应版本至 ${ZIP_BASE_DIR} 目录" || exit


### PR DESCRIPTION
asdlokj1qpi233/subconverter is a community-maintained fork of subconverter which updates rapidly and supports AnyTLS and other new protocols.

Related to #584

## Changes
- `scripts/preflight.sh`: switch subconverter download source
- `scripts/lib/convert.sh`: add timeout to convert request