### PR TITLE
增强订阅下载校验并支持配置 subconverter 来源Improve subscription fetch validation and configurable subconverter source

### DIFF
--- a/.env.install
+++ b/.env.install
@@ -28,5 +28,10 @@ VERSION_MIHOMO= # v1.19.25
 VERSION_YQ= # v4.53.2
 VERSION_SUBCONVERTER= # v0.9.0
 
+# subconverter 官方仓库
+# SUBCONVERTER_REPO=tindy2013/subconverter
+# 下方为社区版，支持更多协议
+SUBCONVERTER_REPO=asdlokj1qpi233/subconverter
+
 # Web UI 压缩包
 ZIP_UI=archives/dist.zip

--- a/scripts/lib/convert.sh
+++ b/scripts/lib/convert.sh
@@ -5,11 +5,82 @@ _download_config() {
     local url=$2
     [ "${url:0:4}" = 'file' ] || _okcat '⏳' '正在下载...'
     _download_raw_config "$dest" "$url" || return 1
-    _okcat '🍃' '验证订阅配置...'
-    _valid_config "$dest" || {
-        _failcat '🍂' "验证失败：尝试订阅转换..."
+    _normalize_sub_config "$dest" || return 1
+
+    _is_html_response "$dest" && {
+        _errorcat "订阅响应疑似 HTML 页面，请检查订阅链接或 User-Agent"
+        return 1
+    }
+
+    _is_native_yaml_config "$dest" && {
+        _okcat '🍃' '检测到原生 Clash/Mihomo 配置'
+        _valid_config "$dest" && _valid_sub_nodes "$dest" && return
+        _failcat '🍂' "原生配置验证失败：尝试订阅转换..."
         cat "$dest" >"${dest}.raw"
-        _download_convert_config "$dest" "$url"
+        _download_convert_config "$dest" "$url" || return
+        _normalize_sub_config "$dest" || return
+        _valid_sub_nodes "$dest"
+        return
+    }
+
+    _okcat '🍃' '验证订阅配置...'
+    _valid_config "$dest" && _valid_sub_nodes "$dest" && return
+
+    _failcat '🍂' "验证失败：尝试订阅转换..."
+    cat "$dest" >"${dest}.raw"
+    _download_convert_config "$dest" "$url" || return
+    _normalize_sub_config "$dest" || return
+    _valid_sub_nodes "$dest"
+}
+
+_normalize_sub_config() {
+    local dest=$1
+
+    [ -s "$dest" ] || {
+        _errorcat "订阅响应为空，请检查订阅链接"
+        return 1
+    }
+
+    LC_ALL=C sed -i '1s/^\xEF\xBB\xBF//' "$dest" 2>/dev/null || true
+    sed -i 's/\r$//' "$dest" 2>/dev/null || true
+
+    command -v iconv >/dev/null || return 0
+    iconv -f UTF-8 -t UTF-8 "$dest" >/dev/null 2>&1 && return 0
+
+    local charset
+    for charset in GB18030 GBK BIG5; do
+        iconv -f "$charset" -t UTF-8 "$dest" -o "${dest}.utf8" 2>/dev/null && {
+            /bin/mv -f "${dest}.utf8" "$dest"
+            _okcat '🔤' "订阅已从 $charset 转为 UTF-8"
+            return 0
+        }
+    done
+
+    /usr/bin/rm -f "${dest}.utf8" 2>/dev/null
+    return 0
+}
+
+_is_html_response() {
+    LC_ALL=C grep -qiE '<[[:space:]]*(!doctype|html|head|body|title)([[:space:]>]|$)' "$1"
+}
+
+_is_native_yaml_config() {
+    "$BIN_YQ" -e '
+      ((.proxies // []) | type == "!!seq" and length > 0) or
+      ((.proxy-providers // {}) | type == "!!map" and length > 0)
+    ' "$1" >/dev/null 2>&1
+}
+
+_valid_sub_nodes() {
+    local config=$1 count
+    count=$("$BIN_YQ" '
+      ((.proxies // []) | length) +
+      ((.proxy-providers // {}) | length)
+    ' "$config" 2>/dev/null) || return 0
+
+    [ "${count:-0}" -gt 0 ] || {
+        _errorcat "订阅未解析出任何节点，请检查订阅内容或转换器版本"
+        return 1
     }
 }
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -130,7 +130,7 @@ download_zip() {
         case $item in
         mihomo) _resolve_version VERSION_MIHOMO MetaCubeX/mihomo || exit ;;
         yq) _resolve_version VERSION_YQ mikefarah/yq || exit ;;
-        subconverter) _resolve_version VERSION_SUBCONVERTER tindy2013/subconverter || exit ;;
+        subconverter) _resolve_version VERSION_SUBCONVERTER "$SUBCONVERTER_REPO" || exit ;;
         esac
     done
 
@@ -145,25 +145,25 @@ download_zip() {
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-amd64-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-amd64-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_amd64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
+        url_subconverter=https://github.com/${SUBCONVERTER_REPO}/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux64.tar.gz
         ;;
     *86*)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-386-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-386-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_386.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
+        url_subconverter=https://github.com/${SUBCONVERTER_REPO}/releases/download/${VERSION_SUBCONVERTER}/subconverter_linux32.tar.gz
         ;;
     armv*)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-armv5-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-armv7-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
+        url_subconverter=https://github.com/${SUBCONVERTER_REPO}/releases/download/${VERSION_SUBCONVERTER}/subconverter_armv7.tar.gz
         ;;
     aarch64)
         url_clash=https://github.com/nelvko/clash-for-linux-install/releases/download/clash/clash-linux-arm64-2023.08.17.gz
         url_mihomo=https://github.com/MetaCubeX/mihomo/releases/download/${VERSION_MIHOMO##*-}/mihomo-linux-arm64-${VERSION_MIHOMO}.gz
         url_yq=https://github.com/mikefarah/yq/releases/download/${VERSION_YQ}/yq_linux_arm64.tar.gz
-        url_subconverter=https://github.com/tindy2013/subconverter/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
+        url_subconverter=https://github.com/${SUBCONVERTER_REPO}/releases/download/${VERSION_SUBCONVERTER}/subconverter_aarch64.tar.gz
         ;;
     *)
         _errorcat "未知的架构版本：$arch，请自行下载对应版本至 ${ZIP_BASE_DIR} 目录" || exit


### PR DESCRIPTION
## PR 描述

本 PR 在不改变现有 Shell 架构和命令用法的前提下，增强订阅下载、识别、转换和校验流程，提升对不同机场订阅格式的兼容性。

## 主要改动

### 在 .env.install 中新增 SUBCONVERTER_REPO 配置。
默认使用社区版以支持更多格式转换：asdlokj1qpi233/subconverter
注释了官方版：tindy2013/subconverter
下载 subconverter 时，根据 SUBCONVERTER_REPO 动态选择仓库来源。
### 订阅下载后增加基础规范化处理：
- 空响应直接报错
- 去除 UTF-8 BOM
- 规范 CRLF 换行
- 如果系统已有 iconv，尝试将常见中文编码转换为 UTF-8
- 增加 HTML 响应检测，避免把登录页、错误页误当作订阅继续转换。
- 优先识别原生 Clash/Mihomo YAML 配置。
- 如果包含 proxies 或 proxy-providers，先直接用内核验证
- 验证失败后仍保留 subconverter 兜底转换，兼顾兼容性
- 转换或验证后检查节点/Provider 数量，避免“配置合法但没有节点”的情况静默通过。

## 改动动机

部分订阅源可能返回带 BOM 的配置、非 UTF-8 文本、HTML 错误页，或已经是原生 Mihomo/Clash YAML。如果直接交给 subconverter，可能导致新字段、新协议或 provider 配置丢失。

本次改动希望在保持最小改动的基础上：

- 优先保留原生 Mihomo/Clash 配置
- 对异常响应更早给出明确错误
- 对旧格式或非标准格式继续使用 subconverter 兜底
- 支持用户切换到社区版 subconverter，以获得更多协议兼容能力

## 兼容性

- 不新增命令
- 不新增必需依赖
- 不引入自研二进制
- 不改变现有 CLASHCTL_SUB_UA 行为
- iconv 仅在系统已存在时使用，不作为安装前置依赖