### PR TITLE
修复了使用`sudo bash install.sh`进行安装时的一系列问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ -n "$SUDO_USER" ]; then
+    export HOME=$(eval echo "~$SUDO_USER")
+fi
+
 CLASHCTL_SRC="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 . "$CLASHCTL_SRC/scripts/preflight.sh"
 
@@ -24,4 +28,10 @@ _valid_config "$CLASH_CONFIG_BASE" && {
     CLASHCTL_SUB_URL="file://$CLASH_CONFIG_BASE"
 }
 clashsub add --use "$CLASHCTL_SUB_URL"
+
+if [ -n "$SUDO_USER" ] && [ -d "$CLASHCTL_HOME" ]; then
+    SUDO_GROUP=$(id -gn "$SUDO_USER")
+    chown -R "${SUDO_USER}:${SUDO_GROUP}" "$CLASHCTL_HOME"
+fi
+
 _okcat '🎉' "请执行 source ~/.bashrc 为当前 SHELL 加载 clashctl 命令"

--- a/scripts/cmd/off.sh
+++ b/scripts/cmd/off.sh
@@ -30,9 +30,6 @@ off_service_only() {
             service_sudo_stop || _errorcat "请先关闭 Tun 模式" || return
         }
         service_is_active >&/dev/null && {
-            service_sudo_stop >/dev/null 2>&1
-        }
-        service_is_active >&/dev/null && {
             _failcat "$CLASHCTL_KERNEL 停止失败"
             return 1
         }

--- a/scripts/cmd/off.sh
+++ b/scripts/cmd/off.sh
@@ -30,6 +30,9 @@ off_service_only() {
             service_sudo_stop || _errorcat "请先关闭 Tun 模式" || return
         }
         service_is_active >&/dev/null && {
+            service_sudo_stop >/dev/null 2>&1
+        }
+        service_is_active >&/dev/null && {
             _failcat "$CLASHCTL_KERNEL 停止失败"
             return 1
         }

--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -4,11 +4,31 @@ service_manager=
 service_log_path=
 service_pid_path=
 
+_sudo() {
+    if _is_root; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
 detect_service_manager() {
     [ -n "$service_manager" ] && return 0
     [ -z "$INIT_TYPE" ] && INIT_TYPE=$(readlink /proc/1/exe 2>/dev/null || echo "nohup")
     grep -qsE "docker|kubepods|containerd|podman|lxc" /proc/1/cgroup 2>/dev/null && INIT_TYPE='nohup'
-    _is_root || INIT_TYPE='nohup'
+
+    if ! _is_root; then
+        if [ -f "/etc/systemd/system/${CLASHCTL_KERNEL}.service" ]; then
+            INIT_TYPE="systemd"
+        elif [ -f "/etc/init.d/${CLASHCTL_KERNEL}" ]; then
+            INIT_TYPE="init"
+        elif [ -d "/etc/sv/${CLASHCTL_KERNEL}" ]; then
+            INIT_TYPE="runit"
+        else
+            INIT_TYPE='nohup'
+        fi
+    fi
+
     INIT_TYPE=$(basename "$INIT_TYPE")
 
     case "$INIT_TYPE" in
@@ -45,16 +65,16 @@ service_start() {
     detect_service_manager
     case "$service_manager" in
     systemd)
-        systemctl start "$CLASHCTL_KERNEL"
+        _sudo systemctl start "$CLASHCTL_KERNEL"
         ;;
     sysvinit)
-        service "$CLASHCTL_KERNEL" start
+        _sudo service "$CLASHCTL_KERNEL" start
         ;;
     openrc)
-        rc-service "$CLASHCTL_KERNEL" start
+        _sudo rc-service "$CLASHCTL_KERNEL" start
         ;;
     runit)
-        sv up "$CLASHCTL_KERNEL"
+        _sudo sv up "$CLASHCTL_KERNEL"
         ;;
     nohup | *)
         (
@@ -65,8 +85,12 @@ service_start() {
 }
 
 service_sudo_start() {
-    _is_root && service_start && return 0
     detect_service_manager
+    if [ "$service_manager" != "nohup" ]; then
+        service_start
+        return $?
+    fi
+    _is_root && service_start && return 0
     (
         sudo sh -c "nohup '$BIN_KERNEL' -d '$CLASH_RESOURCES_DIR' -f '$CLASH_CONFIG_RUNTIME' </dev/null > '$service_log_path' 2>&1 &"
         stty opost 2>/dev/null
@@ -74,6 +98,11 @@ service_sudo_start() {
 }
 
 service_sudo_stop() {
+    detect_service_manager
+    if [ "$service_manager" != "nohup" ]; then
+        service_stop
+        return $?
+    fi
     _is_root && service_stop && return 0
     sudo pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
     sleep 0.2
@@ -85,16 +114,16 @@ service_stop() {
     detect_service_manager
     case "$service_manager" in
     systemd)
-        systemctl stop "$CLASHCTL_KERNEL"
+        _sudo systemctl stop "$CLASHCTL_KERNEL"
         ;;
     sysvinit)
-        service "$CLASHCTL_KERNEL" stop
+        _sudo service "$CLASHCTL_KERNEL" stop
         ;;
     openrc)
-        rc-service "$CLASHCTL_KERNEL" stop
+        _sudo rc-service "$CLASHCTL_KERNEL" stop
         ;;
     runit)
-        sv down "$CLASHCTL_KERNEL"
+        _sudo sv down "$CLASHCTL_KERNEL"
         ;;
     nohup | *)
         pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
@@ -108,16 +137,16 @@ service_restart() {
     detect_service_manager
     case "$service_manager" in
     systemd)
-        systemctl restart "$CLASHCTL_KERNEL"
+        _sudo systemctl restart "$CLASHCTL_KERNEL"
         ;;
     sysvinit)
-        service "$CLASHCTL_KERNEL" restart
+        _sudo service "$CLASHCTL_KERNEL" restart
         ;;
     openrc)
-        rc-service "$CLASHCTL_KERNEL" restart
+        _sudo rc-service "$CLASHCTL_KERNEL" restart
         ;;
     runit)
-        sv restart "$CLASHCTL_KERNEL"
+        _sudo sv restart "$CLASHCTL_KERNEL"
         ;;
     nohup | *)
         service_stop >/dev/null 2>&1

--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -75,13 +75,9 @@ service_sudo_start() {
 
 service_sudo_stop() {
     _is_root && service_stop && return 0
-    if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
-        sudo systemctl stop "$CLASHCTL_KERNEL" 2>/dev/null
-    else
-        sudo pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
-        sleep 0.2
-        sudo pkill -KILL -x "$CLASHCTL_KERNEL" 2>/dev/null
-    fi
+    sudo pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
+    sleep 0.2
+    sudo pkill -KILL -x "$CLASHCTL_KERNEL" 2>/dev/null
     stty opost 2>/dev/null
 }
 

--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -75,9 +75,13 @@ service_sudo_start() {
 
 service_sudo_stop() {
     _is_root && service_stop && return 0
-    sudo pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
-    sleep 0.2
-    sudo pkill -KILL -x "$CLASHCTL_KERNEL" 2>/dev/null
+    if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+        sudo systemctl stop "$CLASHCTL_KERNEL" 2>/dev/null
+    else
+        sudo pkill -TERM -x "$CLASHCTL_KERNEL" 2>/dev/null
+        sleep 0.2
+        sudo pkill -KILL -x "$CLASHCTL_KERNEL" 2>/dev/null
+    fi
     stty opost 2>/dev/null
 }
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -252,7 +252,7 @@ detect_rc() {
     local USER_HOME="${HOME}"
 
     if [ -n "${SUDO_USER}" ]; then
-        USER_HOME=$(eval echo "~{SUDO_USER}")
+        USER_HOME=$(eval echo "~${SUDO_USER}")
     fi
 
     command -v bash >&/dev/null && {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -256,7 +256,7 @@ detect_rc() {
     fi
 
     command -v bash >&/dev/null && {
-        SHELL_RC_BASH="${HOME}/.bashrc"
+        SHELL_RC_BASH="${USER_HOME}/.bashrc"
     }
     command -v zsh >&/dev/null && {
         SHELL_RC_ZSH="${USER_HOME}/.zshrc"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -249,14 +249,20 @@ install_clashctl() {
 }
 
 detect_rc() {
+    local USER_HOME="${HOME}"
+
+    if [ -n "${SUDO_USER}" ]; then
+        USER_HOME=$(eval echo "~{SUDO_USER}")
+    fi
+
     command -v bash >&/dev/null && {
         SHELL_RC_BASH="${HOME}/.bashrc"
     }
     command -v zsh >&/dev/null && {
-        SHELL_RC_ZSH="${HOME}/.zshrc"
+        SHELL_RC_ZSH="${USER_HOME}/.zshrc"
     }
     command -v fish >&/dev/null && {
-        SHELL_RC_FISH="${HOME}/.config/fish/conf.d/clashctl.fish"
+        SHELL_RC_FISH="${USER_HOME}/.config/fish/conf.d/clashctl.fish"
     }
 }
 apply_rc() {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -249,22 +249,17 @@ install_clashctl() {
 }
 
 detect_rc() {
-    local USER_HOME="${HOME}"
-
-    if [ -n "${SUDO_USER}" ]; then
-        USER_HOME=$(eval echo "~${SUDO_USER}")
-    fi
-
     command -v bash >&/dev/null && {
-        SHELL_RC_BASH="${USER_HOME}/.bashrc"
+        SHELL_RC_BASH="${HOME}/.bashrc"
     }
     command -v zsh >&/dev/null && {
-        SHELL_RC_ZSH="${USER_HOME}/.zshrc"
+        SHELL_RC_ZSH="${HOME}/.zshrc"
     }
     command -v fish >&/dev/null && {
-        SHELL_RC_FISH="${USER_HOME}/.config/fish/conf.d/clashctl.fish"
+        SHELL_RC_FISH="${HOME}/.config/fish/conf.d/clashctl.fish"
     }
 }
+
 apply_rc() {
     detect_rc
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ -n "$SUDO_USER" ]; then
+    export HOME=$(eval echo "~$SUDO_USER")
+fi
+
 CLASHCTL_SRC="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 . "$CLASHCTL_SRC/scripts/preflight.sh"
 . "$CLASHCTL_SRC/scripts/cmd/off.sh"


### PR DESCRIPTION
我在使用`sudo bash install.sh`时发现它会注入到root/.bashrc下，而不是我的bashrc中，于是我通过在安装和卸载脚本的开头修改 HOME 的值的方式修复了它
并且修复了提权安装用户使用clashon、clashoff 等命令会失败的bug
修复后我进行了三种安装方式的测试，它们都能正常工作
