### PR TITLE
fix: 改进订阅下载兼容性，非原生配置时用 clash.meta UA 自动重试

### DIFF
--- a/scripts/cmd/sub.sh
+++ b/scripts/cmd/sub.sh
@@ -123,6 +123,7 @@ EOF
     _logging_sub "➕ 已添加订阅：[$id] $url"
     _okcat '🎉' "订阅已添加：[$id] $url"
     [ "$use_after_add" = true ] && _sub_use "$id"
+    return 0
 }
 
 _sub_del() {

--- a/scripts/lib/convert.sh
+++ b/scripts/lib/convert.sh
@@ -66,8 +66,8 @@ _is_html_response() {
 
 _is_native_yaml_config() {
     "$BIN_YQ" -e '
-      ((.proxies // []) | type == "!!seq" and length > 0) or
-      ((.proxy-providers // {}) | type == "!!map" and length > 0)
+      ((.proxies // []) | (type == "!!seq" and length > 0)) or
+      ((.proxy-providers // {}) | (type == "!!map" and length > 0))
     ' "$1" >/dev/null 2>&1
 }
 
@@ -88,6 +88,23 @@ _download_raw_config() {
     local dest=$1
     local url=$2
 
+    _curl_download "$dest" "$url" "$CLASHCTL_SUB_UA" ||
+        _wget_download "$dest" "$url" "$CLASHCTL_SUB_UA"
+
+    # 首次下载结果非原生 YAML 时，自动用 clash.meta UA 重试一次
+    # 常见场景：UA=mihomo → 订阅端返回 base64 编码（缺 anytls/hy2 节点）
+    if ! _is_native_yaml_config "$dest"; then
+        local backup_ua="$CLASHCTL_SUB_UA"
+        [ "$backup_ua" = 'clash.meta' ] && return 0
+        _failcat '🍂' "UA=${backup_ua} 响应非原生配置，用 clash.meta 重试..."
+        _curl_download "$dest" "$url" 'clash.meta' ||
+            _wget_download "$dest" "$url" 'clash.meta'
+    fi
+    return 0
+}
+
+_curl_download() {
+    local dest=$1 url=$2 ua=$3
     curl \
         --silent \
         --show-error \
@@ -96,17 +113,21 @@ _download_raw_config() {
         --location \
         --max-time "$CLASHCTL_SUB_TIMEOUT" \
         --retry 1 \
-        --user-agent "$CLASHCTL_SUB_UA" \
+        --user-agent "$ua" \
         --output "$dest" \
-        "$url" ||
-        wget \
-            --no-verbose \
-            --no-check-certificate \
-            --timeout "$CLASHCTL_SUB_TIMEOUT" \
-            --tries 1 \
-            --user-agent "$CLASHCTL_SUB_UA" \
-            --output-document "$dest" \
-            "$url"
+        "$url"
+}
+
+_wget_download() {
+    local dest=$1 url=$2 ua=$3
+    wget \
+        --no-verbose \
+        --no-check-certificate \
+        --timeout "$CLASHCTL_SUB_TIMEOUT" \
+        --tries 1 \
+        --user-agent "$ua" \
+        --output-document "$dest" \
+        "$url"
 }
 
 _download_convert_config() {
@@ -156,6 +177,7 @@ _start_convert() {
     curl --silent --fail "$check_url" >/dev/null 2>&1 && return 0
 
     "$BIN_SUBCONVERTER" >"$BIN_SUBCONVERTER_LOG" 2>&1 &
+    disown "$!" 2>/dev/null
 
     local start now
     start=$(date +%s)


### PR DESCRIPTION
- _is_native_yaml_config: 修正 yq 表达式括号，避免误判
- _download_raw_config: 拆分 _curl_download / _wget_download 辅助函数
- 首次下载非原生 YAML 时自动用 clash.meta UA 重试一次
- _sub_add: 补 return 0 修复返回值
- _start_convert: 后台 subconverter 进程加 disown 防止脚本退出被收编
