### PR TITLE
feat(mixin): 新增 inject-all，向所有手动选择组注入节点

### DIFF
--- a/resources/mixin.yaml
+++ b/resources/mixin.yaml
@@ -13,6 +13,8 @@ authentication:
 # append   后置追加：追加到原列表末尾，适用于 rules、proxies、proxy-groups
 # override 整体替换：按 name 匹配并替换整个项目，适用于 proxies、proxy-groups
 # inject   节点注入：向指定 proxy-group 的 proxies 列表注入节点，仅适用于 proxy-groups
+# inject-all 全组注入：向所有手动选择组（type: select）注入节点，无需逐个写组名，换订阅零改动
+# inject-all-exclude 注入排除：组名正则，命中的组不参与 inject-all
 
 # 示例：https://github.com/nelvko/clash-for-linux-install/discussions/562
 rules:
@@ -31,6 +33,8 @@ proxy-groups:
   append:
   override:
   inject:
+  inject-all:
+  inject-all-exclude:
 
 # tun 配置
 tun:

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -162,12 +162,35 @@ _merge_config() {
 
       ########################################
       #         ProxyGroups Inject           #
+      # inject-all 仅注入手动选择组，且跳过    #
+      # mixin 自己 prepend/append 的组，避免   #
+      # 链式代理被注入到自己的出站组而成环     #
       ########################################
       ($mixin.proxy-groups.inject // {}) as $inj |
+      ($mixin.proxy-groups.inject-all // []) as $injAll |
+      ($mixin.proxy-groups.inject-all-exclude // "") as $injAllExclude |
+      (
+        (($mixin.proxy-groups.prepend // []) + ($mixin.proxy-groups.append // []))
+        | map(.name)
+      ) as $mixinNames |
       .proxy-groups[] |= (
         . as $g |
-        ($inj | .[$g.name] // []) as $extra |
-        .proxies = (.proxies + $extra | unique)
+        (
+          ($inj | .[$g.name] // []) +
+          (
+            (
+              $injAll | select(
+                ($g.type == "select") and
+                (($mixinNames | any_c(. == $g.name)) | not) and
+                (($injAllExclude == "") or (($g.name | test($injAllExclude)) | not))
+              )
+            ) // []
+          )
+        ) as $extra |
+        with(
+          select(($extra | length) > 0);
+          .proxies = ((.proxies // []) + $extra | unique)
+        )
       )
     ' "$CLASH_CONFIG_BASE" "$CLASH_CONFIG_MIXIN" >"$CLASH_CONFIG_RUNTIME"
 


### PR DESCRIPTION
## 背景

现有的 `proxy-groups.inject` 需要逐个写死订阅里的组名：

```yaml
proxy-groups:
  inject:
    "🔰 选择节点":
      - "我的链式代理"
    "♻️ 手动切换":
      - "我的链式代理"
```

组名是机场订阅自带的，一旦换订阅（或机场调整组名／emoji），注入就静默失效，得回来手工改一遍 mixin。常见诉求其实是「把我自建的节点塞进**所有能手选的组**里」，而不是关心具体叫什么名字。

## 方案

新增 `inject-all`，向所有手动选择组注入节点，换订阅零改动：

```yaml
proxy-groups:
  inject-all:
    - "我的链式代理"
  # 可选：组名正则，命中的组不参与注入
  inject-all-exclude: "(?i)拦截广告|国内网站|直连"
```

三条边界，都是为了让默认行为足够安全：

1. **只注入 `type: select` 的组**。`url-test` / `fallback` / `load-balance` 这类自动测速组不注入，自建节点不会被测速逻辑自动选中。
2. **跳过 mixin 自己 `prepend` / `append` 定义的组**。链式代理的 `dialer-proxy` 通常指向一个自建的出站组，若把该链式节点又注入回这个出站组，面板上一手滑选中就直接成环。
3. **`inject-all-exclude`**：组名正则兜底，用于放过广告拦截、国内直连这类功能组。

注入是**追加**且 `unique` 保序，各组的默认选中项（首项）不变。`inject` 与 `inject-all` 可以并存。

## 顺带修正 inject

原实现 `.proxies = (.proxies + $extra | unique)` 对**没有 `proxies` 键**的组（只靠 `include-all` / `use` 取节点的组）会写入一个空的 `proxies: []`。现改为仅在确有注入项时才写，并用 `(.proxies // [])` 兜底 null。

## 实现说明

`inject-all` 放在原有的后置 `.proxy-groups[] |= (...)` 阶段，而不是 `.proxy-groups = (prepend + map(...) + append)` 的 `map` 里面 —— 后者在 yq 下会静默失效：数组拼接后整体赋值时，`map` 内新增的 key 会被丢弃（改动已有 key 则正常）。所以对「本来没有 `proxies` 键」的组，写在 `map` 里注入不进去。这一条踩过坑，记在这里备查。

组名匹配用 `any_c(. == $g.name)` 精确比较，没用 `contains`（后者对字符串做子串匹配，组名互为前缀时会误判）。

## 测试

`config.yaml` 造了覆盖各类组的用例，跑合并后：

| 组 | type | 结果 |
|---|---|---|
| `🔰 选择节点` | select | 注入 ✅ |
| `☁️ OneDrive`（仅 include-all，无 proxies 键） | select | 注入 ✅ |
| `♻️ 自动选择` | url-test | 不注入 ✅ |
| `🔁 中继` | relay | 不注入 ✅ |
| `🛑 拦截广告`（命中 exclude） | select | 不注入 ✅ |
| `出站`（mixin 自己 prepend 的组） | select | 不注入 ✅ |

**回归**：不配置 `inject-all` 时（含 `proxy-groups` 各键全为 null 的默认 mixin），新旧实现输出逐行 diff 一致，唯一差异是上面那个空 `proxies: []` 不再写入。

**实际环境**：mihomo v1.19.17 + yq v4.49.2，真实订阅（11 个 select 组）合并后 `mihomo -t` 校验通过并已在日常使用；逐组核对首项（默认选中项）未变，`proxy-groups` 以外的配置零变化。

## 兼容性

纯新增键，取值都有 `// []` / `// ""` 兜底，不配置即完全维持现有行为。已按现有风格在 `resources/mixin.yaml` 顶部注释和 `proxy-groups` 下补了占位键。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
