### PR TITLE
feat: add per-Linux-user proxy traffic accounting dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ archives/*
 test.sh
 
 !.gitkeep
+
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **广泛兼容**：支持 `root` / 普通用户，适配主流 `Linux` 发行版、容器环境及 `systemd` / `OpenRC` 等 `init` 系统。
 - **统一管理**：通过 `clashctl` 管理代理启停、状态查看、日志追踪、Web 面板、TUN 模式、访问密钥与内核升级等。
 - **订阅管理**：支持多订阅源配置、一键切换、定时更新，并集成 [subconverter](https://github.com/tindy2013/subconverter) 实现订阅格式转换。
+- **流量统计**：按认证账号、Linux UID 或来源 IP 汇总代理流量，并提供本地 Web 仪表盘和 CSV 导出。
 
 ## 🚀 Installation
 
@@ -35,6 +36,48 @@ git clone --branch master --depth 1 https://gh-proxy.org/https://github.com/nelv
 - 上述命令使用了[加速前缀](https://gh-proxy.org/)，如失效请更换其他[可用链接](https://ghproxy.link/)。
 - 可通过 `.env.install` 文件自定义安装选项。
 - 没有订阅？[click me](https://次元.net/auth/register?code=oUbI)
+
+## 📊 Traffic accounting
+
+`clashctl traffic` 从 Mihomo `/connections` 接口定期读取连接字节计数，按可识别身份聚合并保存到本地 SQLite。该功能需要 **Python 3.10 或更高版本**。
+
+```bash
+# 启动采集器和仅监听本机的仪表盘
+clashctl traffic start
+
+# 查看状态、今日排行和当前活跃连接
+clashctl traffic status
+clashctl traffic today
+clashctl traffic live
+
+# 查看最近 24 小时并导出最近 7 天 CSV
+clashctl traffic top 24h
+clashctl traffic export --since 7d > traffic.csv
+
+# 显示仪表盘地址和远程 SSH 隧道示例
+clashctl traffic ui
+
+# 停止采集器
+clashctl traffic stop
+```
+
+默认仪表盘地址为 `http://127.0.0.1:8765`，不会监听公网地址。远程服务器建议通过 SSH 隧道访问：
+
+```bash
+ssh -N -L 8765:127.0.0.1:8765 <server>
+```
+
+统计数据库位于 `${XDG_STATE_HOME:-~/.local/state}/clashctl/traffic.sqlite3`，目录和数据库权限分别限制为 `700` 和 `600`。采集器只持久化身份、归属类型、置信度和字节增量，不保存目标域名、目标地址、进程路径、流量内容或 Mihomo 控制密钥。
+
+统计保留两个不同字段：
+
+- `user_id`：仅表示 Linux UID，JSON 中为整数；无法映射到本机 Linux 用户时为 `null`，CSV 中为空。
+- `identity_key`：通用归属键，可为 `uid:<UID>`、`account:<inboundUser>`、`source-ip:<IP>` 或 `unknown`。
+
+归属顺序为：代理认证账号优先；本机 loopback 连接按 `sourcePort` 从 `/proc/net/{tcp,tcp6,udp,udp6}` 唯一反查 Linux UID；然后才使用 Mihomo 返回的正数 UID、来源 IP 和 `unknown`。`/proc` 反查只在每轮采样时读取一次，不持久化端口、inode 或进程路径。
+
+> [!IMPORTANT]
+> 这是基于连接接口的采样统计，不是计费级计量。连接第一次出现时只建立基线；短连接可能在两次采样之间完成，连接消失前最后一段流量也无法追溯；采集器停止期间的流量不会补记。要可靠区分远程用户，请为每个用户配置独立的代理认证账号。
 
 ## 📖 Documentation
 

--- a/scripts/cmd/help.sh
+++ b/scripts/cmd/help.sh
@@ -18,6 +18,7 @@ Commands:
   secret                Web 密钥
   log                   查看日志
   upgrade               升级内核
+  traffic               代理流量统计与仪表盘
 
 Global Options:
   -h, --help            显示帮助信息

--- a/scripts/cmd/traffic.sh
+++ b/scripts/cmd/traffic.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 traffic_python() {
+    if [ -n "${CLASHCTL_TRAFFIC_PYTHON:-}" ]; then
+        [ -x "$CLASHCTL_TRAFFIC_PYTHON" ] || return 1
+        printf '%s\n' "$CLASHCTL_TRAFFIC_PYTHON"
+        return 0
+    fi
     command -v python3 2>/dev/null || command -v python 2>/dev/null
 }
 

--- a/scripts/cmd/traffic.sh
+++ b/scripts/cmd/traffic.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+
+traffic_python() {
+    command -v python3 2>/dev/null || command -v python 2>/dev/null
+}
+
+traffic_script() {
+    printf '%s/scripts/traffic/traffic.py\n' "$CLASHCTL_HOME"
+}
+
+traffic_state_dir() {
+    local root=${XDG_STATE_HOME:-${HOME}/.local/state}
+    printf '%s/clashctl\n' "$root"
+}
+
+traffic_port() {
+    printf '%s\n' "${CLASHCTL_TRAFFIC_PORT:-8765}"
+}
+
+traffic_interval() {
+    printf '%s\n' "${CLASHCTL_TRAFFIC_INTERVAL:-5}"
+}
+
+traffic_validate_port() {
+    local port=$1
+    [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -ge 1024 ] && [ "$port" -le 65535 ] && return 0
+    _errorcat '端口必须是 1024-65535 之间的整数'
+}
+
+traffic_validate_interval() {
+    local interval=$1
+    awk -v value="$interval" 'BEGIN { exit !(value ~ /^[0-9]+([.][0-9]+)?$/ && value >= 1) }' && return 0
+    _errorcat '采样间隔必须是大于等于 1 的数字'
+}
+
+traffic_health() {
+    local port=$1
+    curl --silent --show-error --fail --max-time 1 \
+        "http://127.0.0.1:${port}/api/health" >/dev/null 2>&1
+}
+
+traffic_require_runtime() {
+    local python
+    python=$(traffic_python) || {
+        _errorcat '系统未找到 python3，无法启动流量采集器'
+        return 1
+    }
+    "$python" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))' || {
+        _errorcat '流量统计需要 Python 3.10 或更高版本'
+        return 1
+    }
+    [ -f "$(traffic_script)" ] || {
+        _errorcat "流量组件不存在：$(traffic_script)"
+        return 1
+    }
+    printf '%s\n' "$python"
+}
+
+traffic_python_run() {
+    local python=$1
+    shift
+    "$python" "$(traffic_script)" "$@"
+}
+
+traffic_start() {
+    local interval=$(traffic_interval)
+    local port=$(traffic_port)
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --interval)
+            [ $# -ge 2 ] || { _errorcat '--interval 需要一个秒数'; return 2; }
+            interval=$2
+            shift 2
+            ;;
+        --port)
+            [ $# -ge 2 ] || { _errorcat '--port 需要一个端口'; return 2; }
+            port=$2
+            shift 2
+            ;;
+        -h|--help)
+            traffic_help
+            return 0
+            ;;
+        *)
+            _errorcat "未知选项：$1"
+            return 2
+            ;;
+        esac
+    done
+
+    traffic_validate_port "$port" || return 2
+    traffic_validate_interval "$interval" || return 2
+
+    local python
+    python=$(traffic_require_runtime) || return
+    local state_dir=$(traffic_state_dir)
+    local log_path="$state_dir/traffic.log"
+    mkdir -p "$state_dir"
+    chmod 700 "$state_dir"
+
+    if traffic_python_run "$python" status --state-dir "$state_dir" >/dev/null 2>&1; then
+        traffic_health "$port" && {
+            _okcat "流量采集器已运行：http://127.0.0.1:${port}"
+            return 0
+        }
+        _errorcat "流量采集器进程已运行，但端口 ${port} 的仪表盘不可用；请先执行 clashctl traffic stop"
+        return 1
+    fi
+
+    nohup "$python" "$(traffic_script)" serve \
+        --config-path "$CLASH_CONFIG_RUNTIME" \
+        --state-dir "$state_dir" \
+        --host 127.0.0.1 \
+        --port "$port" \
+        --interval "$interval" \
+        >>"$log_path" 2>&1 < /dev/null &
+
+    local attempt=0
+    while [ "$attempt" -lt 50 ]; do
+        if traffic_python_run "$python" status --state-dir "$state_dir" >/dev/null 2>&1 \
+            && traffic_health "$port"; then
+            _okcat "流量采集器已启动：http://127.0.0.1:${port}"
+            return 0
+        fi
+        sleep 0.1
+        attempt=$((attempt + 1))
+    done
+
+    traffic_python_run "$python" stop --state-dir "$state_dir" >/dev/null 2>&1 || true
+    _errorcat "流量采集器启动失败，请检查日志：$log_path"
+    return 1
+}
+
+traffic_stop() {
+    local python
+    python=$(traffic_require_runtime) || return
+    traffic_python_run "$python" stop --state-dir "$(traffic_state_dir)"
+    local attempt=0
+    while [ "$attempt" -lt 30 ]; do
+        traffic_python_run "$python" status --state-dir "$(traffic_state_dir)" >/dev/null 2>&1 || {
+            _okcat '流量采集器已停止'
+            return 0
+        }
+        sleep 0.1
+        attempt=$((attempt + 1))
+    done
+    _errorcat '流量采集器停止请求已发送，但进程仍在运行'
+    return 1
+}
+
+traffic_status() {
+    local python
+    python=$(traffic_require_runtime) || return
+    traffic_python_run "$python" status --state-dir "$(traffic_state_dir)"
+}
+
+traffic_ui() {
+    local port=$(traffic_port)
+    local previous=
+    for previous in "$@"; do
+        if [ "${expect_port:-false}" = true ]; then
+            port=$previous
+            expect_port=false
+            continue
+        fi
+        [ "$previous" = --port ] && expect_port=true
+    done
+    traffic_start "$@" || return
+    cat <<EOF
+
+流量仪表盘已启动：
+  本机访问：http://127.0.0.1:${port}
+
+远程访问（在本地终端建立 SSH 隧道）：
+  ssh -F ~/.ssh/config.server-mesh -N -L ${port}:127.0.0.1:${port} <mesh-host>
+  然后打开：http://127.0.0.1:${port}
+
+EOF
+}
+
+traffic_report() {
+    local python
+    python=$(traffic_require_runtime) || return
+    local since=${1:-today}
+    traffic_python_run "$python" report --state-dir "$(traffic_state_dir)" --since "$since"
+}
+
+traffic_live() {
+    local python
+    python=$(traffic_require_runtime) || return
+    traffic_python_run "$python" live --state-dir "$(traffic_state_dir)"
+}
+
+traffic_export() {
+    local python
+    python=$(traffic_require_runtime) || return
+    local since=today
+    local until=
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        --since)
+            [ $# -ge 2 ] || { _errorcat '--since 需要一个时间范围'; return 2; }
+            since=$2
+            shift 2
+            ;;
+        --until)
+            [ $# -ge 2 ] || { _errorcat '--until 需要一个时间范围'; return 2; }
+            until=$2
+            shift 2
+            ;;
+        -h|--help)
+            traffic_help
+            return 0
+            ;;
+        *)
+            _errorcat "未知选项：$1"
+            return 2
+            ;;
+        esac
+    done
+    if [ -n "$until" ]; then
+        traffic_python_run "$python" export --state-dir "$(traffic_state_dir)" --since "$since" --until "$until"
+    else
+        traffic_python_run "$python" export --state-dir "$(traffic_state_dir)" --since "$since"
+    fi
+}
+
+clashtraffic() {
+    case "${1:-status}" in
+    start)
+        shift
+        traffic_start "$@"
+        ;;
+    stop)
+        shift
+        traffic_stop "$@"
+        ;;
+    status)
+        shift
+        traffic_status "$@"
+        ;;
+    ui|open)
+        shift
+        traffic_ui "$@"
+        ;;
+    today)
+        shift
+        traffic_report today "$@"
+        ;;
+    top|report)
+        shift
+        traffic_report "${1:-today}"
+        ;;
+    live)
+        shift
+        traffic_live "$@"
+        ;;
+    export)
+        shift
+        traffic_export "$@"
+        ;;
+    -h|--help|help)
+        traffic_help
+        ;;
+    *)
+        traffic_help
+        return 2
+        ;;
+    esac
+}
+
+traffic_help() {
+    cat <<EOF
+
+clashctl traffic - 代理流量采集与仪表盘
+
+Usage:
+  clashctl traffic COMMAND [OPTIONS]
+
+Commands:
+  start [--interval SEC] [--port PORT] 启动本地采集器与仪表盘
+  stop                              停止采集器
+  status                            查看采集器状态
+  ui                                启动并显示仪表盘访问方式
+  today                             查看今天的身份流量汇总
+  top [RANGE]                       查看指定范围的身份流量排行
+  live                              查看最近一次采样的活跃连接
+  export [OPTIONS]                  导出 CSV
+
+Export options:
+  --since RANGE                     today、24h、7d 或 ISO-8601 时间
+  --until RANGE                     结束时间（默认 now）
+
+安全边界：仪表盘只监听 127.0.0.1；统计只保存身份与字节增量，不保存目标地址或流量内容。
+EOF
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -267,6 +267,7 @@ install_clashctl() {
     /bin/cp -a "$CLASHCTL_SRC/scripts/cmd" "$target_dir/scripts/"
     /bin/cp -a "$CLASHCTL_SRC/scripts/lib" "$target_dir/scripts/"
     /bin/cp -a "$CLASHCTL_SRC/scripts/init" "$target_dir/scripts/"
+    /bin/cp -a "$CLASHCTL_SRC/scripts/traffic" "$target_dir/scripts/"
 
     for resource in "$CLASHCTL_SRC"/resources/*; do
         /bin/cp -r "$resource" "$target_dir/resources/"

--- a/scripts/traffic/collector.py
+++ b/scripts/traffic/collector.py
@@ -205,12 +205,19 @@ def local_socket_uid(
     return snapshot.get((network, source_port))
 
 
+def _connection_list(payload: dict[str, Any]) -> list[Any]:
+    connections = payload.get("connections")
+    if connections is None:
+        return []
+    if not isinstance(connections, list):
+        raise TrafficError("Mihomo 返回中缺少 connections 列表")
+    return connections
+
+
 def collect_once(store: TrafficStore, controller: str, secret: str) -> dict[str, int]:
     try:
         payload = fetch_connections(controller, secret)
-        connections = payload.get("connections")
-        if not isinstance(connections, list):
-            raise TrafficError("Mihomo 返回中缺少 connections 列表")
+        connections = _connection_list(payload)
         socket_uids = proc_socket_uid_snapshot()
         samples = []
         for item in connections:

--- a/scripts/traffic/collector.py
+++ b/scripts/traffic/collector.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Mihomo controller client and sampler lifecycle helpers."""
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import json
+import os
+import re
+import signal
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from model import normalize_connection, parse_int
+from store import TrafficStore, utc_now
+
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
+class TrafficError(RuntimeError):
+    """A safe, user-facing collector error."""
+
+
+def _strip_yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    if " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
+    return value
+
+
+def runtime_connection_config(config_path: Path) -> tuple[str, str]:
+    """Read only top-level controller fields without a YAML dependency."""
+    controller = "127.0.0.1:9090"
+    secret = ""
+    try:
+        lines = config_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        raise TrafficError(f"无法读取 Mihomo runtime 配置：{config_path}") from exc
+    for line in lines:
+        match = re.match(r"^(external-controller|secret):\s*(.*)$", line)
+        if not match:
+            continue
+        value = _strip_yaml_scalar(match.group(2))
+        if match.group(1) == "external-controller":
+            controller = value or controller
+        else:
+            secret = value
+    return controller, secret
+
+
+def controller_address(controller: str) -> str:
+    value = (controller or "").strip()
+    if value.startswith("[") and "]" in value:
+        host = value[1 : value.index("]")]
+        suffix = value[value.index("]") + 1 :]
+        port = int(suffix[1:]) if suffix.startswith(":") else 9090
+    elif ":" in value:
+        host, port_value = value.rsplit(":", 1)
+        port = int(port_value)
+    else:
+        host, port = value or "127.0.0.1", 9090
+    if host in {"0.0.0.0", "::", "[::]", ""}:
+        host = "127.0.0.1"
+    return f"{host}:{port}"
+
+
+def _read_response(response: Any) -> bytes:
+    chunks: list[bytes] = []
+    size = 0
+    while True:
+        chunk = response.read(64 * 1024)
+        if not chunk:
+            break
+        size += len(chunk)
+        if size > MAX_RESPONSE_BYTES:
+            raise TrafficError("Mihomo connections 响应超过安全大小限制")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def fetch_connections(controller: str, secret: str) -> dict[str, Any]:
+    request = urllib.request.Request(f"http://{controller_address(controller)}/connections")
+    if secret:
+        request.add_header("Authorization", f"Bearer {secret}")
+    try:
+        with urllib.request.urlopen(request, timeout=4) as response:
+            payload = _read_response(response)
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
+        raise TrafficError(f"Mihomo 控制接口不可用：{type(exc).__name__}") from exc
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise TrafficError("Mihomo 控制接口返回了无效 JSON") from exc
+    if not isinstance(value, dict):
+        raise TrafficError("Mihomo 控制接口返回格式不正确")
+    return value
+
+
+def proc_socket_uid_snapshot(
+    proc_net: Path = Path("/proc/net"),
+) -> dict[tuple[str, int], int]:
+    """Return unambiguous local-port owners from Linux proc socket tables."""
+    owners: dict[tuple[str, int], set[int]] = {}
+    for name in ("tcp", "tcp6", "udp", "udp6"):
+        path = proc_net / name
+        try:
+            lines = path.read_text(encoding="ascii", errors="replace").splitlines()[1:]
+        except OSError:
+            continue
+        network = "tcp" if name.startswith("tcp") else "udp"
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 8:
+                continue
+            try:
+                local_port = int(fields[1].rsplit(":", 1)[1], 16)
+                uid = int(fields[7])
+            except (IndexError, ValueError):
+                continue
+            if 0 < local_port <= 65535 and uid >= 0:
+                owners.setdefault((network, local_port), set()).add(uid)
+    return {
+        key: next(iter(values))
+        for key, values in owners.items()
+        if len(values) == 1
+    }
+
+
+def local_socket_uid(
+    metadata: dict[str, Any], snapshot: dict[tuple[str, int], int]
+) -> int | None:
+    """Resolve a loopback client's Linux UID from its local source port."""
+    source_ip = str(metadata.get("sourceIP") or "").strip().strip("[]")
+    try:
+        address = ipaddress.ip_address(source_ip.split("%", 1)[0])
+    except ValueError:
+        return None
+    if address.version == 6 and address.ipv4_mapped is not None:
+        address = address.ipv4_mapped
+    if not address.is_loopback:
+        return None
+    try:
+        source_port = int(metadata.get("sourcePort"))
+    except (TypeError, ValueError):
+        return None
+    if not 0 < source_port <= 65535:
+        return None
+    network = str(metadata.get("network") or "tcp").strip().lower()
+    if network not in {"tcp", "udp"}:
+        return None
+    return snapshot.get((network, source_port))
+
+
+def collect_once(store: TrafficStore, controller: str, secret: str) -> dict[str, int]:
+    try:
+        payload = fetch_connections(controller, secret)
+        connections = payload.get("connections")
+        if not isinstance(connections, list):
+            raise TrafficError("Mihomo 返回中缺少 connections 列表")
+        socket_uids = proc_socket_uid_snapshot()
+        samples = []
+        for item in connections:
+            if not isinstance(item, dict):
+                continue
+            metadata = item.get("metadata")
+            metadata = metadata if isinstance(metadata, dict) else {}
+            samples.append(
+                normalize_connection(
+                    item,
+                    local_uid=local_socket_uid(metadata, socket_uids),
+                )
+            )
+        return store.record_sample(
+            samples,
+            utc_now(),
+            parse_int(payload.get("uploadTotal"))
+            if payload.get("uploadTotal") is not None
+            else None,
+            parse_int(payload.get("downloadTotal"))
+            if payload.get("downloadTotal") is not None
+            else None,
+        )
+    except TrafficError as exc:
+        store.record_error(str(exc))
+        raise
+
+
+def pid_path(state_dir: Path) -> Path:
+    return state_dir / "traffic.pid"
+
+
+def read_pid(state_dir: Path) -> int | None:
+    try:
+        return int(pid_path(state_dir).read_text(encoding="ascii").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def process_matches(pid: int, state_dir: Path) -> bool:
+    try:
+        command = Path(f"/proc/{pid}/cmdline").read_bytes().replace(b"\0", b" ").decode()
+    except (OSError, UnicodeDecodeError):
+        return False
+    return "traffic.py" in command and str(state_dir) in command
+
+
+def is_running(state_dir: Path) -> tuple[bool, int | None]:
+    pid = read_pid(state_dir)
+    return bool(pid and process_matches(pid, state_dir)), pid
+
+
+def acquire_pid_file(state_dir: Path) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = pid_path(state_dir)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        existing = read_pid(state_dir)
+        if existing and process_matches(existing, state_dir):
+            raise TrafficError(f"采集器已在运行（PID {existing}）")
+        path.unlink(missing_ok=True)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="ascii") as handle:
+        handle.write(str(os.getpid()))
+
+
+def remove_pid_file(state_dir: Path) -> None:
+    try:
+        pid_path(state_dir).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def stop_collector(state_dir: Path) -> bool:
+    running, pid = is_running(state_dir)
+    if not running or not pid:
+        remove_pid_file(state_dir)
+        return False
+    os.kill(pid, signal.SIGTERM)
+    return True

--- a/scripts/traffic/collector.py
+++ b/scripts/traffic/collector.py
@@ -17,6 +17,8 @@ from model import normalize_connection, parse_int
 from store import TrafficStore, utc_now
 
 MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+DEFAULT_CONTROLLER = "127.0.0.1:9090"
+ALLOWED_NETWORKS = frozenset({"tcp", "udp"})
 
 
 class TrafficError(RuntimeError):
@@ -34,8 +36,9 @@ def _strip_yaml_scalar(value: str) -> str:
 
 def runtime_connection_config(config_path: Path) -> tuple[str, str]:
     """Read only top-level controller fields without a YAML dependency."""
-    controller = "127.0.0.1:9090"
-    secret = ""
+    controller = DEFAULT_CONTROLLER
+    # An empty string means the controller has no configured secret.
+    secret = str()  # nosec B105
     try:
         lines = config_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError as exc:
@@ -52,19 +55,47 @@ def runtime_connection_config(config_path: Path) -> tuple[str, str]:
     return controller, secret
 
 
+def _validated_port(port_text: str) -> int:
+    port = int(port_text)
+    if not 1 <= port <= 65535:
+        raise ValueError("Mihomo controller 端口必须在 1-65535 之间")
+    return port
+
+
+def _bracketed_host_port(value: str) -> tuple[str, int]:
+    closing = value.find("]")
+    if closing < 0:
+        raise ValueError("Mihomo controller IPv6 地址缺少右括号")
+    host = value[1:closing]
+    suffix = value[closing + 1 :]
+    if suffix and not suffix.startswith(":"):
+        raise ValueError("Mihomo controller IPv6 地址格式不正确")
+    return host, _validated_port(suffix[1:] if suffix else "9090")
+
+
+def _plain_host_port(value: str) -> tuple[str, int]:
+    if value.count(":") > 1:
+        raise ValueError("Mihomo controller IPv6 地址必须使用方括号")
+    host, separator, port_text = value.rpartition(":")
+    if not separator:
+        host, port_text = value, "9090"
+    return host, _validated_port(port_text)
+
+
+def _controller_host_port(value: str) -> tuple[str, int]:
+    if any(character in value for character in ("/", "@", "?", "#")):
+        raise ValueError("Mihomo controller 必须是 host:port，不能包含 URL 组件")
+    return _bracketed_host_port(value) if value.startswith("[") else _plain_host_port(value)
+
+
 def controller_address(controller: str) -> str:
-    value = (controller or "").strip()
-    if value.startswith("[") and "]" in value:
-        host = value[1 : value.index("]")]
-        suffix = value[value.index("]") + 1 :]
-        port = int(suffix[1:]) if suffix.startswith(":") else 9090
-    elif ":" in value:
-        host, port_value = value.rsplit(":", 1)
-        port = int(port_value)
-    else:
-        host, port = value or "127.0.0.1", 9090
-    if host in {"0.0.0.0", "::", "[::]", ""}:
+    value = (controller or DEFAULT_CONTROLLER).strip()
+    host, port = _controller_host_port(value)
+    wildcard_ipv4 = str(ipaddress.ip_address(0))
+    if host in {wildcard_ipv4, "::", ""}:
         host = "127.0.0.1"
+    elif ":" in host:
+        host = f"[{host}]"
     return f"{host}:{port}"
 
 
@@ -87,7 +118,8 @@ def fetch_connections(controller: str, secret: str) -> dict[str, Any]:
     if secret:
         request.add_header("Authorization", f"Bearer {secret}")
     try:
-        with urllib.request.urlopen(request, timeout=4) as response:
+        # controller_address() rejects schemes, paths, userinfo, and invalid ports.
+        with urllib.request.urlopen(request, timeout=4) as response:  # nosec B310
             payload = _read_response(response)
     except (OSError, urllib.error.URLError, http.client.HTTPException) as exc:
         raise TrafficError(f"Mihomo 控制接口不可用：{type(exc).__name__}") from exc
@@ -100,29 +132,40 @@ def fetch_connections(controller: str, secret: str) -> dict[str, Any]:
     return value
 
 
+def _proc_socket_owner(line: str) -> tuple[int, int] | None:
+    fields = line.split()
+    if len(fields) < 8:
+        return None
+    try:
+        local_port = int(fields[1].rsplit(":", 1)[1], 16)
+        uid = int(fields[7])
+    except (IndexError, ValueError):
+        return None
+    if not 0 < local_port <= 65535 or uid < 0:
+        return None
+    return local_port, uid
+
+
+def _socket_table_lines(path: Path) -> list[str]:
+    try:
+        return path.read_text(encoding="ascii", errors="replace").splitlines()[1:]
+    except OSError:
+        return []
+
+
 def proc_socket_uid_snapshot(
     proc_net: Path = Path("/proc/net"),
 ) -> dict[tuple[str, int], int]:
     """Return unambiguous local-port owners from Linux proc socket tables."""
     owners: dict[tuple[str, int], set[int]] = {}
     for name in ("tcp", "tcp6", "udp", "udp6"):
-        path = proc_net / name
-        try:
-            lines = path.read_text(encoding="ascii", errors="replace").splitlines()[1:]
-        except OSError:
-            continue
         network = "tcp" if name.startswith("tcp") else "udp"
-        for line in lines:
-            fields = line.split()
-            if len(fields) < 8:
+        for line in _socket_table_lines(proc_net / name):
+            owner = _proc_socket_owner(line)
+            if owner is None:
                 continue
-            try:
-                local_port = int(fields[1].rsplit(":", 1)[1], 16)
-                uid = int(fields[7])
-            except (IndexError, ValueError):
-                continue
-            if 0 < local_port <= 65535 and uid >= 0:
-                owners.setdefault((network, local_port), set()).add(uid)
+            local_port, uid = owner
+            owners.setdefault((network, local_port), set()).add(uid)
     return {
         key: next(iter(values))
         for key, values in owners.items()
@@ -130,27 +173,34 @@ def proc_socket_uid_snapshot(
     }
 
 
+def _loopback_address(value: Any) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    source_ip = str(value or "").strip().strip("[]").split("%", 1)[0]
+    try:
+        address = ipaddress.ip_address(source_ip)
+    except ValueError:
+        return None
+    if address.version == 6 and address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    return address if address.is_loopback else None
+
+
+def _source_port(value: Any) -> int | None:
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        return None
+    return port if 0 < port <= 65535 else None
+
+
 def local_socket_uid(
     metadata: dict[str, Any], snapshot: dict[tuple[str, int], int]
 ) -> int | None:
     """Resolve a loopback client's Linux UID from its local source port."""
-    source_ip = str(metadata.get("sourceIP") or "").strip().strip("[]")
-    try:
-        address = ipaddress.ip_address(source_ip.split("%", 1)[0])
-    except ValueError:
+    if _loopback_address(metadata.get("sourceIP")) is None:
         return None
-    if address.version == 6 and address.ipv4_mapped is not None:
-        address = address.ipv4_mapped
-    if not address.is_loopback:
-        return None
-    try:
-        source_port = int(metadata.get("sourcePort"))
-    except (TypeError, ValueError):
-        return None
-    if not 0 < source_port <= 65535:
-        return None
+    source_port = _source_port(metadata.get("sourcePort"))
     network = str(metadata.get("network") or "tcp").strip().lower()
-    if network not in {"tcp", "udp"}:
+    if source_port is None or network not in ALLOWED_NETWORKS:
         return None
     return snapshot.get((network, source_port))
 

--- a/scripts/traffic/dashboard.html
+++ b/scripts/traffic/dashboard.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>clashctl / traffic</title>
+  <style>
+    :root {
+      --ink: #091015;
+      --panel: #101a20;
+      --panel-2: #15232a;
+      --line: #26353b;
+      --muted: #8ca0a6;
+      --text: #e9f1ef;
+      --mint: #79f2c0;
+      --mint-dim: #2dbf91;
+      --amber: #f6c76b;
+      --coral: #ff806f;
+      --blue: #75b8ff;
+      --unknown: #68777d;
+      --shadow: rgba(0, 0, 0, .28);
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--ink); }
+    body {
+      margin: 0;
+      min-width: 320px;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 82% -10%, rgba(121, 242, 192, .12), transparent 35rem),
+        linear-gradient(135deg, #091015 0%, #0d171d 52%, #091015 100%);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: .01em;
+    }
+    button { font: inherit; }
+    .shell { width: min(1480px, calc(100% - 44px)); margin: 0 auto; padding: 28px 0 44px; }
+    .masthead { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; padding-bottom: 26px; border-bottom: 1px solid var(--line); }
+    .eyebrow { color: var(--mint); font: 700 11px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .18em; text-transform: uppercase; }
+    h1 { margin: 8px 0 0; font: 650 clamp(30px, 5vw, 58px)/.95 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: -.08em; }
+    .lead { max-width: 510px; margin: 13px 0 0; color: var(--muted); font-size: 14px; line-height: 1.6; }
+    .status-cluster { display: flex; align-items: center; gap: 12px; padding-top: 4px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .status-dot { width: 9px; height: 9px; border-radius: 99px; background: var(--mint); box-shadow: 0 0 0 5px rgba(121, 242, 192, .1), 0 0 18px var(--mint); }
+    .status-dot[data-bad="true"] { background: var(--coral); box-shadow: 0 0 0 5px rgba(255, 128, 111, .1), 0 0 18px var(--coral); }
+    .hero { display: grid; grid-template-columns: 1.15fr .85fr; gap: 18px; padding: 28px 0 18px; }
+    .hero-card, .card { min-width: 0; border: 1px solid var(--line); background: linear-gradient(145deg, rgba(21, 35, 42, .96), rgba(13, 23, 29, .96)); box-shadow: 0 18px 50px var(--shadow); }
+    .hero-card { position: relative; overflow: hidden; padding: clamp(24px, 4vw, 42px); min-height: 260px; }
+    .hero-card::after { content: ""; position: absolute; right: -60px; bottom: -100px; width: 300px; height: 300px; border: 1px solid rgba(121, 242, 192, .3); border-radius: 50%; box-shadow: 0 0 0 22px rgba(121, 242, 192, .025), 0 0 0 44px rgba(121, 242, 192, .025); }
+    .hero-label { color: var(--muted); font-size: 12px; }
+    .total { position: relative; z-index: 1; margin: 30px 0 12px; font: 600 clamp(44px, 7vw, 92px)/.9 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: -.08em; color: var(--amber); }
+    .hero-note { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 9px 20px; color: var(--muted); font-size: 13px; }
+    .hero-note strong { color: var(--text); font-weight: 600; }
+    .controls { display: flex; flex-direction: column; justify-content: space-between; padding: 22px; }
+    .controls-title { display: flex; justify-content: space-between; align-items: center; gap: 16px; color: var(--muted); font-size: 12px; }
+    .range { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+    .range button { cursor: pointer; border: 1px solid var(--line); border-radius: 0; color: var(--muted); background: rgba(9, 16, 21, .75); padding: 9px 12px; font: 700 11px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; text-transform: uppercase; }
+    .range button:hover, .range button:focus-visible { border-color: var(--mint-dim); color: var(--text); outline: none; }
+    .range button[aria-pressed="true"] { border-color: var(--mint); background: rgba(121, 242, 192, .11); color: var(--mint); }
+    .health { margin-top: 30px; padding-top: 20px; border-top: 1px solid var(--line); }
+    .health-line { display: flex; justify-content: space-between; gap: 16px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .health-line strong { color: var(--mint); font-weight: 500; }
+    .health-line strong[data-bad="true"] { color: var(--coral); }
+    .kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding: 0 0 18px; }
+    .kpi { padding: 18px; border: 1px solid var(--line); background: rgba(16, 26, 32, .88); }
+    .kpi-label { color: var(--muted); font-size: 12px; }
+    .kpi-value { margin-top: 10px; font: 550 25px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: -.05em; }
+    .kpi-sub { margin-top: 8px; color: var(--muted); font-size: 11px; }
+    .grid { min-width: 0; display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(340px, .65fr); gap: 18px; }
+    .card { padding: 20px; }
+    .card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+    .card-title { margin: 0; font-size: 15px; font-weight: 650; }
+    .card-meta { margin-top: 5px; color: var(--muted); font-size: 12px; }
+    .legend { display: flex; flex-wrap: wrap; gap: 12px; color: var(--muted); font-size: 11px; }
+    .legend span { display: inline-flex; align-items: center; gap: 6px; }
+    .legend i { width: 7px; height: 7px; display: inline-block; border-radius: 50%; background: var(--mint); }
+    .legend .up i { background: var(--coral); }
+    .legend .unknown i { background: var(--unknown); }
+    .chart-wrap { position: relative; min-height: 280px; }
+    #timeline { width: 100%; height: 280px; overflow: visible; }
+    .chart-empty { position: absolute; inset: 30% 10%; display: grid; place-items: center; color: var(--muted); text-align: center; font-size: 13px; }
+    .chart-empty[hidden] { display: none; }
+    .users-card { grid-column: 1 / -1; }
+    .table-wrap { min-width: 0; max-width: 100%; overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; min-width: 720px; }
+    th { padding: 0 10px 12px; color: var(--muted); border-bottom: 1px solid var(--line); text-align: left; font: 700 10px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .11em; text-transform: uppercase; }
+    td { padding: 15px 10px; border-bottom: 1px solid rgba(38, 53, 59, .7); font-size: 13px; vertical-align: middle; }
+    tbody tr:hover { background: rgba(121, 242, 192, .035); }
+    .identity { display: flex; align-items: center; gap: 11px; min-width: 190px; }
+    .avatar { display: grid; place-items: center; width: 30px; height: 30px; border: 1px solid rgba(121, 242, 192, .35); color: var(--mint); font: 700 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .identity-name { color: var(--text); font-weight: 600; }
+    .identity-kind { margin-top: 3px; color: var(--muted); font-size: 11px; }
+    .user-id { margin-top: 4px; color: var(--mint); font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .bytes { font: 13px ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
+    .share { min-width: 180px; }
+    .bar { height: 5px; background: #223138; }
+    .bar > span { display: block; height: 100%; background: linear-gradient(90deg, var(--mint-dim), var(--mint)); }
+    .confidence { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 11px; }
+    .confidence::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--unknown); }
+    .confidence[data-level="high"]::before { background: var(--mint); }
+    .confidence[data-level="medium"]::before { background: var(--amber); }
+    .live-list { display: grid; gap: 10px; }
+    .live-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px; background: rgba(9, 16, 21, .58); border-left: 2px solid var(--mint-dim); }
+    .live-name { font-weight: 600; font-size: 13px; }
+    .live-detail { margin-top: 5px; color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .live-total { color: var(--mint); font: 13px ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
+    .footnote { margin-top: 18px; color: var(--muted); font-size: 11px; line-height: 1.7; }
+    .error { color: var(--coral); }
+    @media (max-width: 940px) { .hero, .grid { grid-template-columns: 1fr; } .kpis { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 560px) { .shell { width: min(100% - 28px, 1480px); padding-top: 18px; } .masthead { flex-direction: column; } .kpis { grid-template-columns: 1fr 1fr; gap: 8px; } .kpi { padding: 13px; } .kpi-value { font-size: 19px; } .total { font-size: 56px; } .card-head { flex-direction: column; } .legend { width: 100%; } }
+    @media (prefers-reduced-motion: reduce) { * { scroll-behavior: auto !important; transition: none !important; } }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="masthead">
+      <div>
+        <div class="eyebrow">clashctl / traffic telemetry</div>
+        <h1>谁在使用代理</h1>
+        <p class="lead">按可识别身份汇总 Mihomo 的连接字节增量。只保留统计，不保留目标地址或流量内容。</p>
+      </div>
+      <div class="status-cluster"><span class="status-dot" id="status-dot"></span><span id="status-text">连接采集中</span></div>
+    </header>
+
+    <section class="hero" aria-label="traffic overview">
+      <div class="hero-card">
+        <div class="hero-label">selected range / total traffic</div>
+        <div class="total" id="hero-total">—</div>
+        <div class="hero-note"><span>下载 <strong id="hero-download">—</strong></span><span>上传 <strong id="hero-upload">—</strong></span><span>身份覆盖 <strong id="hero-coverage">—</strong></span></div>
+      </div>
+      <div class="card controls">
+        <div>
+          <div class="controls-title"><span>观察窗口</span><span id="last-sample">等待首个采样</span></div>
+          <div class="range" role="group" aria-label="观察窗口">
+            <button type="button" data-range="today" aria-pressed="true">今天</button>
+            <button type="button" data-range="24h" aria-pressed="false">24 小时</button>
+            <button type="button" data-range="7d" aria-pressed="false">7 天</button>
+          </div>
+        </div>
+        <div class="health">
+          <div class="eyebrow">collector health</div>
+          <div class="health-line"><span>数据源</span><strong id="source-state">检测中</strong></div>
+          <div class="health-line"><span>采样间隔</span><span id="sample-interval">—</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="kpis" aria-label="summary metrics">
+      <div class="kpi"><div class="kpi-label">tracked identities</div><div class="kpi-value" id="tracked-users">—</div><div class="kpi-sub">当前窗口有流量记录</div></div>
+      <div class="kpi"><div class="kpi-label">active now</div><div class="kpi-value" id="active-users">—</div><div class="kpi-sub">最近一次采样的活跃身份</div></div>
+      <div class="kpi"><div class="kpi-label">download / upload</div><div class="kpi-value" id="ratio">—</div><div class="kpi-sub">方向比例</div></div>
+      <div class="kpi"><div class="kpi-label">samples</div><div class="kpi-value" id="sample-count">—</div><div class="kpi-sub">采集器累计采样次数</div></div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <div class="card-head"><div><h2 class="card-title">Traffic signal</h2><div class="card-meta">按 5 分钟聚合；实线为已采样数据，断点代表采集器没有成功采样。</div></div><div class="legend"><span><i></i>下载</span><span class="up"><i></i>上传</span><span class="unknown"><i></i>采样空洞</span></div></div>
+        <div class="chart-wrap"><svg id="timeline" viewBox="0 0 900 280" role="img" aria-label="traffic over time"></svg><div class="chart-empty" id="chart-empty">还没有足够的采样数据<br>启动采集器后，这里会出现流量信号。</div></div>
+      </article>
+      <article class="card">
+        <div class="card-head"><div><h2 class="card-title">On the wire</h2><div class="card-meta">最近一次采样中的活跃连接</div></div></div>
+        <div class="live-list" id="live-list"><div class="card-meta">等待连接数据…</div></div>
+      </article>
+      <article class="card users-card">
+        <div class="card-head"><div><h2 class="card-title">Identity ledger</h2><div class="card-meta">统计按总字节排序；Linux user_id 仅显示数值 UID，无法映射时显示为空。</div></div><div class="card-meta" id="table-range">—</div></div>
+        <div class="table-wrap"><table><thead><tr><th>身份</th><th>下载</th><th>上传</th><th>总计 / 占比</th><th>归属置信度</th></tr></thead><tbody id="users-body"><tr><td colspan="5" class="card-meta">等待采样数据…</td></tr></tbody></table></div>
+        <div class="footnote">这是基于连接接口的采样统计，不是计费级计量。每条连接第一次出现时只建立基线；采集器停止期间产生的流量不会被追溯补记。要获得高置信度的远程用户归属，请为不同用户配置独立代理认证账号。</div>
+      </article>
+    </section>
+  </main>
+  <script>
+    (() => {
+      const state = { range: 'today', summary: null, series: [], live: [] };
+      const $ = (id) => document.getElementById(id);
+      const fmt = (bytes) => {
+        if (!Number.isFinite(bytes)) return '—';
+        const units = ['B', 'KB', 'MB', 'GB', 'TB']; let n = Math.max(0, bytes), i = 0;
+        while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+        return `${n >= 100 || i === 0 ? n.toFixed(0) : n.toFixed(1)} ${units[i]}`;
+      };
+      const pct = (value) => `${(Number(value) || 0).toFixed(1)}%`;
+      const escInitial = (name) => (name || '?').trim().slice(0, 1).toUpperCase();
+      const timeLabel = (ts) => new Date(ts * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const setText = (id, text) => { $(id).textContent = text; };
+      const create = (tag, className, text) => { const node = document.createElement(tag); if (className) node.className = className; if (text !== undefined) node.textContent = text; return node; };
+
+      function setHealth(health) {
+        const ok = Boolean(health && health.controller_reachable);
+        $('status-dot').dataset.bad = ok ? 'false' : 'true';
+        setText('status-text', ok ? '连接采集中' : '等待数据源');
+        const source = $('source-state'); source.textContent = ok ? 'Mihomo online' : (health?.last_error || 'unreachable'); source.dataset.bad = ok ? 'false' : 'true';
+        setText('sample-interval', health?.sample_interval ? `${health.sample_interval}s` : '—');
+        setText('last-sample', health?.last_sample_at ? `last ${new Date(health.last_sample_at).toLocaleTimeString()}` : '等待首个采样');
+      }
+
+      function renderSummary(summary) {
+        state.summary = summary;
+        setText('hero-total', fmt(summary.total)); setText('hero-download', fmt(summary.download)); setText('hero-upload', fmt(summary.upload)); setText('hero-coverage', pct(summary.attribution_percent));
+        setText('tracked-users', String(summary.tracked_identities ?? 0)); setText('active-users', String(summary.active_identities ?? 0));
+        setText('ratio', summary.total ? `${Math.round(summary.download * 100 / summary.total)} / ${Math.round(summary.upload * 100 / summary.total)}` : '—'); setText('sample-count', String(summary.sample_count ?? 0));
+        setText('table-range', summary.since ? new Date(summary.since).toLocaleString() : '—');
+        renderUsers(summary.users || []);
+      }
+
+      function renderUsers(users) {
+        const body = $('users-body'); body.replaceChildren();
+        if (!users.length) { const row = create('tr'); const cell = create('td', 'card-meta', '还没有流量增量。'); cell.colSpan = 5; row.appendChild(cell); body.appendChild(row); return; }
+        const total = users.reduce((sum, user) => sum + Number(user.upload || 0) + Number(user.download || 0), 0);
+        users.forEach((user) => {
+          const upload = Number(user.upload || 0), download = Number(user.download || 0), amount = upload + download, share = total ? amount / total * 100 : 0;
+          const row = create('tr'); const identityCell = create('td'); const identity = create('div', 'identity'); identity.appendChild(create('div', 'avatar', escInitial(user.display_name))); const copy = create('div'); copy.appendChild(create('div', 'identity-name', user.display_name)); copy.appendChild(create('div', 'identity-kind', user.identity_kind)); copy.appendChild(create('div', 'user-id', `Linux user_id: ${user.user_id ?? '—'}`)); copy.appendChild(create('div', 'identity-kind', `identity: ${user.identity_key || 'unknown'}`)); identity.appendChild(copy); identityCell.appendChild(identity); row.appendChild(identityCell);
+          row.appendChild(create('td', 'bytes', fmt(download))); row.appendChild(create('td', 'bytes', fmt(upload)));
+          const shareCell = create('td', 'share'); const shareText = create('div', 'bytes', `${fmt(amount)} · ${pct(share)}`); const bar = create('div', 'bar'); const fill = create('span'); fill.style.width = `${Math.min(100, share)}%`; bar.appendChild(fill); shareCell.append(shareText, bar); row.appendChild(shareCell);
+          const confidence = create('span', 'confidence', user.confidence); confidence.dataset.level = user.confidence; const confidenceCell = create('td'); confidenceCell.appendChild(confidence); row.appendChild(confidenceCell); body.appendChild(row);
+        });
+      }
+
+      function renderLive(items) {
+        const list = $('live-list'); list.replaceChildren();
+        if (!items.length) { list.appendChild(create('div', 'card-meta', '当前没有活跃连接。')); return; }
+        items.forEach((item) => { const row = create('div', 'live-row'); const copy = create('div'); copy.appendChild(create('div', 'live-name', item.display_name)); copy.appendChild(create('div', 'live-detail', `${item.connection_count} connections · ${item.confidence}`)); copy.appendChild(create('div', 'user-id', `Linux user_id: ${item.user_id ?? '—'}`)); copy.appendChild(create('div', 'identity-kind', `identity: ${item.identity_key || 'unknown'}`)); row.appendChild(copy); row.appendChild(create('div', 'live-total', fmt(Number(item.upload_bytes || 0) + Number(item.download_bytes || 0)))); list.appendChild(row); });
+      }
+
+      function svgElement(name, attrs = {}) { const node = document.createElementNS('http://www.w3.org/2000/svg', name); Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, value)); return node; }
+      function renderChart(series) {
+        const svg = $('timeline'); svg.replaceChildren(); const empty = $('chart-empty'); empty.hidden = series.some((point) => Number(point.upload || 0) + Number(point.download || 0) > 0);
+        if (!series.length) return;
+        const W = 900, H = 280, left = 46, right = 14, top = 18, bottom = 34, width = W - left - right, height = H - top - bottom;
+        const max = Math.max(1, ...series.flatMap((point) => [Number(point.upload || 0), Number(point.download || 0)]));
+        [0, .25, .5, .75, 1].forEach((ratio) => { const y = top + height - ratio * height; svg.appendChild(svgElement('line', { x1: left, y1: y, x2: W - right, y2: y, stroke: '#26353b', 'stroke-width': 1 })); const label = svgElement('text', { x: left - 8, y: y + 4, fill: '#8ca0a6', 'font-size': 10, 'text-anchor': 'end' }); label.textContent = fmt(max * ratio); svg.appendChild(label); });
+        const points = series.map((point, index) => ({ x: left + (series.length === 1 ? width / 2 : index / (series.length - 1) * width), point }));
+        const signalPath = (field) => { let path = ''; let active = false; points.forEach((p) => { if (!p.point.sampled) { active = false; return; } const value = Number(p.point[field] || 0); const y = top + height - value / max * height; path += `${active ? 'L' : 'M'}${p.x.toFixed(1)} ${y.toFixed(1)} `; active = true; }); return path.trim(); };
+        points.forEach((p) => { if (!p.point.sampled) svg.appendChild(svgElement('line', { x1: p.x, y1: top, x2: p.x, y2: top + height, stroke: '#68777d', 'stroke-width': 1, 'stroke-dasharray': '3 6', opacity: .55 })); });
+        const downloadPath = signalPath('download'); const uploadPath = signalPath('upload');
+        if (downloadPath) svg.appendChild(svgElement('path', { d: downloadPath, fill: 'none', stroke: '#79f2c0', 'stroke-width': 2 }));
+        if (uploadPath) svg.appendChild(svgElement('path', { d: uploadPath, fill: 'none', stroke: '#ff806f', 'stroke-width': 2 }));
+        [0, Math.floor(series.length / 2), series.length - 1].forEach((index) => { if (!series[index]) return; const text = svgElement('text', { x: points[index].x, y: H - 8, fill: '#8ca0a6', 'font-size': 10, 'text-anchor': index === 0 ? 'start' : (index === series.length - 1 ? 'end' : 'middle') }); text.textContent = timeLabel(series[index].timestamp); svg.appendChild(text); });
+      }
+
+      async function load() {
+        try {
+          const [health, summary, range, live] = await Promise.all([
+            fetch('/api/health').then((response) => response.json()),
+            fetch(`/api/summary?since=${encodeURIComponent(state.range)}`).then((response) => response.json()),
+            fetch(`/api/range?since=${encodeURIComponent(state.range)}`).then((response) => response.json()),
+            fetch('/api/live').then((response) => response.json()),
+          ]);
+          setHealth(health); renderSummary(summary); renderChart(range.series || []); renderLive(live.identities || []);
+        } catch (error) { $('status-dot').dataset.bad = 'true'; setText('status-text', '仪表盘请求失败'); setText('source-state', 'dashboard error'); }
+      }
+      document.querySelectorAll('[data-range]').forEach((button) => button.addEventListener('click', () => { state.range = button.dataset.range; document.querySelectorAll('[data-range]').forEach((item) => item.setAttribute('aria-pressed', String(item === button))); load(); }));
+      load(); setInterval(load, 10000);
+    })();
+  </script>
+</body>
+</html>

--- a/scripts/traffic/model.py
+++ b/scripts/traffic/model.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Identity resolution and Mihomo connection normalization."""
+from __future__ import annotations
+
+import hashlib
+import json
+import pwd
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Identity:
+    key: str
+    label: str
+    kind: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class ConnectionSample:
+    connection_id: str
+    identity: Identity
+    upload: int
+    download: int
+
+
+def parse_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def metadata_for(connection: dict[str, Any]) -> dict[str, Any]:
+    value = connection.get("metadata")
+    return value if isinstance(value, dict) else {}
+
+
+def linux_uid_identity(uid: int) -> Identity:
+    try:
+        label = f"{pwd.getpwuid(uid).pw_name} · uid {uid}"
+    except KeyError:
+        label = f"uid {uid}"
+    return Identity(f"uid:{uid}", label, "linux-user", "high")
+
+
+def identify_connection(
+    metadata: dict[str, Any], local_uid: int | None = None
+) -> Identity:
+    """Resolve identity without retaining socket or destination metadata.
+
+    A UID resolved from the local client socket is trusted, including UID 0.
+    Mihomo's raw UID 0 remains an unavailable sentinel and is not trusted.
+    """
+    inbound_user = str(metadata.get("inboundUser") or "").strip()
+    if inbound_user:
+        return Identity(f"account:{inbound_user}", inbound_user, "account", "high")
+
+    if local_uid is not None and local_uid >= 0:
+        return linux_uid_identity(local_uid)
+
+    uid_value = metadata.get("uid")
+    if uid_value is not None and str(uid_value).strip() != "":
+        try:
+            uid = int(str(uid_value))
+        except ValueError:
+            uid = None
+        if uid is not None and uid > 0:
+            identity = linux_uid_identity(uid)
+            return Identity(identity.key, identity.label, identity.kind, "medium")
+
+    source_ip = str(metadata.get("sourceIP") or "").strip()
+    if source_ip:
+        return Identity(f"source-ip:{source_ip}", source_ip, "source-ip", "low")
+
+    return Identity("unknown", "Unattributed", "unknown", "low")
+
+
+def connection_id(connection: dict[str, Any]) -> str:
+    raw_id = connection.get("id")
+    if raw_id is not None and str(raw_id).strip():
+        return str(raw_id)
+    metadata = metadata_for(connection)
+    seed = {
+        "metadata": {
+            "sourceIP": metadata.get("sourceIP"),
+            "sourcePort": metadata.get("sourcePort"),
+            "inboundPort": metadata.get("inboundPort"),
+            "host": metadata.get("host"),
+        },
+        "start": connection.get("start"),
+    }
+    digest = hashlib.sha256(
+        json.dumps(seed, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:32]
+    return f"synthetic:{digest}"
+
+
+def normalize_connection(
+    connection: dict[str, Any], local_uid: int | None = None
+) -> ConnectionSample:
+    return ConnectionSample(
+        connection_id=connection_id(connection),
+        identity=identify_connection(metadata_for(connection), local_uid=local_uid),
+        upload=parse_int(connection.get("upload")),
+        download=parse_int(connection.get("download")),
+    )

--- a/scripts/traffic/model.py
+++ b/scripts/traffic/model.py
@@ -45,6 +45,17 @@ def linux_uid_identity(uid: int) -> Identity:
     return Identity(f"uid:{uid}", label, "linux-user", "high")
 
 
+def _metadata_uid(metadata: dict[str, Any]) -> int | None:
+    value = metadata.get("uid")
+    if value is None or not str(value).strip():
+        return None
+    try:
+        uid = int(str(value))
+    except ValueError:
+        return None
+    return uid if uid > 0 else None
+
+
 def identify_connection(
     metadata: dict[str, Any], local_uid: int | None = None
 ) -> Identity:
@@ -60,15 +71,10 @@ def identify_connection(
     if local_uid is not None and local_uid >= 0:
         return linux_uid_identity(local_uid)
 
-    uid_value = metadata.get("uid")
-    if uid_value is not None and str(uid_value).strip() != "":
-        try:
-            uid = int(str(uid_value))
-        except ValueError:
-            uid = None
-        if uid is not None and uid > 0:
-            identity = linux_uid_identity(uid)
-            return Identity(identity.key, identity.label, identity.kind, "medium")
+    metadata_uid = _metadata_uid(metadata)
+    if metadata_uid is not None:
+        identity = linux_uid_identity(metadata_uid)
+        return Identity(identity.key, identity.label, identity.kind, "medium")
 
     source_ip = str(metadata.get("sourceIP") or "").strip()
     if source_ip:

--- a/scripts/traffic/server.py
+++ b/scripts/traffic/server.py
@@ -23,18 +23,21 @@ class DashboardHandler(BaseHTTPRequestHandler):
         return
 
     def _send(self, status: int, content_type: str, body: bytes) -> None:
-        self.send_response(status)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("X-Content-Type-Options", "nosniff")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header(
-            "Content-Security-Policy",
-            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
-            "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
-        )
-        self.end_headers()
-        self.wfile.write(body)
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
+                "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
+            )
+            self.end_headers()
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            return
 
     def _json(self, value: Any, status: int = 200) -> None:
         body = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()

--- a/scripts/traffic/server.py
+++ b/scripts/traffic/server.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Loopback dashboard HTTP server."""
+from __future__ import annotations
+
+import json
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+from store import TrafficStore, format_utc
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    server_version = "clashctl-traffic/1"
+
+    @property
+    def dashboard_server(self) -> "DashboardServer":
+        return self.server  # type: ignore[return-value]
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def _send(self, status: int, content_type: str, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
+            "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
+        )
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, value: Any, status: int = 200) -> None:
+        body = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()
+        self._send(status, "application/json; charset=utf-8", body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        try:
+            if parsed.path in {"/", "/index.html"}:
+                self._send(200, "text/html; charset=utf-8", self.dashboard_server.dashboard_html)
+                return
+            if parsed.path == "/api/health":
+                self._json(self.dashboard_server.health())
+                return
+            if parsed.path == "/api/summary":
+                since = params.get("since", ["today"])[0]
+                self._json(
+                    self.dashboard_server.store.summary(
+                        self.dashboard_server.store.since_value(since)
+                    )
+                )
+                return
+            if parsed.path == "/api/range":
+                since = params.get("since", ["24h"])[0]
+                self._json(
+                    {
+                        "since": since,
+                        "series": self.dashboard_server.store.series(
+                            self.dashboard_server.store.since_value(since)
+                        ),
+                    }
+                )
+                return
+            if parsed.path == "/api/live":
+                self._json({"identities": self.dashboard_server.store.live()})
+                return
+            self._json({"error": "not_found"}, 404)
+        except ValueError as exc:
+            self._json({"error": str(exc)}, 400)
+        except Exception:
+            self._json({"error": "internal_error"}, 500)
+
+
+class DashboardServer(HTTPServer):
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        store: TrafficStore,
+        dashboard_html: bytes,
+        interval: float,
+    ):
+        super().__init__(address, DashboardHandler)
+        self.store = store
+        self.dashboard_html = dashboard_html
+        self.interval = interval
+        self.started_at = int(time.time())
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "collector": "clashctl-traffic",
+            "started_at": format_utc(self.started_at),
+            "last_sample_at": format_utc(self.store.get_meta("last_sample_at")),
+            "controller_reachable": self.store.get_meta("controller_reachable") == "1",
+            "last_error": self.store.get_meta("last_error") or None,
+            "sample_interval": self.interval,
+            "dashboard_bind": f"{self.server_address[0]}:{self.server_address[1]}",
+        }
+
+
+def load_dashboard(script_path: Path) -> bytes:
+    dashboard = script_path.with_name("dashboard.html")
+    try:
+        return dashboard.read_bytes()
+    except OSError as exc:
+        raise RuntimeError(f"找不到 dashboard.html：{dashboard}") from exc

--- a/scripts/traffic/store.py
+++ b/scripts/traffic/store.py
@@ -12,6 +12,62 @@ from typing import Any, Iterable
 from model import ConnectionSample
 
 STALE_CONNECTION_SECONDS = 180
+EMPTY_SERIES_BUCKET = {
+    "upload": 0,
+    "download": 0,
+    "attributed": 0,
+    "unattributed": 0,
+    "sampled": False,
+}
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS traffic_minute (
+    bucket_start INTEGER NOT NULL,
+    identity_key TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    identity_kind TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    upload_bytes INTEGER NOT NULL DEFAULT 0,
+    download_bytes INTEGER NOT NULL DEFAULT 0,
+    samples INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (bucket_start, identity_key)
+);
+CREATE INDEX IF NOT EXISTS idx_traffic_minute_bucket
+    ON traffic_minute(bucket_start);
+
+CREATE TABLE IF NOT EXISTS sample_minute (
+    bucket_start INTEGER PRIMARY KEY,
+    samples INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS connection_state (
+    connection_id TEXT PRIMARY KEY,
+    identity_key TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    identity_kind TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    upload_bytes INTEGER NOT NULL,
+    download_bytes INTEGER NOT NULL,
+    last_seen INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_connection_state_last_seen
+    ON connection_state(last_seen);
+
+CREATE TABLE IF NOT EXISTS live_identity (
+    identity_key TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    identity_kind TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    connection_count INTEGER NOT NULL,
+    upload_bytes INTEGER NOT NULL,
+    download_bytes INTEGER NOT NULL,
+    observed_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS collector_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
 
 
 def utc_now() -> int:
@@ -42,7 +98,8 @@ class TrafficStore:
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            os.chmod(self.path.parent, 0o700)
+            # The state directory is intentionally accessible only by its owner.
+            os.chmod(self.path.parent, 0o700)  # nosec B103
         except OSError:
             pass
         self.connection = sqlite3.connect(self.path, timeout=30)
@@ -59,57 +116,7 @@ class TrafficStore:
         self.connection.close()
 
     def _create_schema(self) -> None:
-        self.connection.executescript(
-            """
-            CREATE TABLE IF NOT EXISTS traffic_minute (
-                bucket_start INTEGER NOT NULL,
-                identity_key TEXT NOT NULL,
-                display_name TEXT NOT NULL,
-                identity_kind TEXT NOT NULL,
-                confidence TEXT NOT NULL,
-                upload_bytes INTEGER NOT NULL DEFAULT 0,
-                download_bytes INTEGER NOT NULL DEFAULT 0,
-                samples INTEGER NOT NULL DEFAULT 0,
-                PRIMARY KEY (bucket_start, identity_key)
-            );
-            CREATE INDEX IF NOT EXISTS idx_traffic_minute_bucket
-                ON traffic_minute(bucket_start);
-
-            CREATE TABLE IF NOT EXISTS sample_minute (
-                bucket_start INTEGER PRIMARY KEY,
-                samples INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE IF NOT EXISTS connection_state (
-                connection_id TEXT PRIMARY KEY,
-                identity_key TEXT NOT NULL,
-                display_name TEXT NOT NULL,
-                identity_kind TEXT NOT NULL,
-                confidence TEXT NOT NULL,
-                upload_bytes INTEGER NOT NULL,
-                download_bytes INTEGER NOT NULL,
-                last_seen INTEGER NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_connection_state_last_seen
-                ON connection_state(last_seen);
-
-            CREATE TABLE IF NOT EXISTS live_identity (
-                identity_key TEXT PRIMARY KEY,
-                display_name TEXT NOT NULL,
-                identity_kind TEXT NOT NULL,
-                confidence TEXT NOT NULL,
-                connection_count INTEGER NOT NULL,
-                upload_bytes INTEGER NOT NULL,
-                download_bytes INTEGER NOT NULL,
-                observed_at INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS collector_meta (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            );
-            """
-        )
+        self.connection.executescript(SCHEMA_SQL)
         self.connection.commit()
 
     def set_meta(self, key: str, value: Any) -> None:
@@ -130,6 +137,157 @@ class TrafficStore:
         self.set_meta("controller_reachable", "0")
         self.connection.commit()
 
+    def _previous_counters(self, connection_id: str) -> tuple[int, int] | None:
+        row = self.connection.execute(
+            "SELECT upload_bytes, download_bytes FROM connection_state "
+            "WHERE connection_id = ?",
+            (connection_id,),
+        ).fetchone()
+        return (int(row[0]), int(row[1])) if row is not None else None
+
+    @staticmethod
+    def _counter_delta(current: int, previous: int) -> int:
+        return current - previous if current >= previous else current
+
+    def _sample_delta(self, sample: ConnectionSample) -> tuple[int, int]:
+        previous = self._previous_counters(sample.connection_id)
+        if previous is None:
+            return 0, 0
+        return (
+            self._counter_delta(sample.upload, previous[0]),
+            self._counter_delta(sample.download, previous[1]),
+        )
+
+    def _upsert_connection(self, sample: ConnectionSample, observed_at: int) -> None:
+        identity = sample.identity
+        self.connection.execute(
+            "INSERT INTO connection_state("
+            "connection_id, identity_key, display_name, identity_kind, "
+            "confidence, upload_bytes, download_bytes, last_seen) "
+            "VALUES(?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(connection_id) DO UPDATE SET "
+            "identity_key=excluded.identity_key, display_name=excluded.display_name, "
+            "identity_kind=excluded.identity_kind, confidence=excluded.confidence, "
+            "upload_bytes=excluded.upload_bytes, download_bytes=excluded.download_bytes, "
+            "last_seen=excluded.last_seen",
+            (
+                sample.connection_id,
+                identity.key,
+                identity.label,
+                identity.kind,
+                identity.confidence,
+                sample.upload,
+                sample.download,
+                observed_at,
+            ),
+        )
+
+    @staticmethod
+    def _identity_totals(
+        target: dict[str, dict[str, Any]], sample: ConnectionSample
+    ) -> dict[str, Any]:
+        return target.setdefault(
+            sample.identity.key,
+            {
+                "identity": sample.identity,
+                "connections": 0,
+                "upload": 0,
+                "download": 0,
+            },
+        )
+
+    def _accumulate_sample(
+        self,
+        sample: ConnectionSample,
+        observed_at: int,
+        deltas: dict[str, dict[str, Any]],
+        live: dict[str, dict[str, Any]],
+    ) -> tuple[int, int]:
+        delta_upload, delta_download = self._sample_delta(sample)
+        if delta_upload or delta_download:
+            delta_item = self._identity_totals(deltas, sample)
+            delta_item["upload"] += delta_upload
+            delta_item["download"] += delta_download
+        live_item = self._identity_totals(live, sample)
+        live_item["connections"] += 1
+        live_item["upload"] += sample.upload
+        live_item["download"] += sample.download
+        self._upsert_connection(sample, observed_at)
+        return delta_upload, delta_download
+
+    def _upsert_traffic_deltas(
+        self, bucket: int, deltas: dict[str, dict[str, Any]]
+    ) -> None:
+        for item in deltas.values():
+            identity = item["identity"]
+            self.connection.execute(
+                "INSERT INTO traffic_minute("
+                "bucket_start, identity_key, display_name, identity_kind, "
+                "confidence, upload_bytes, download_bytes, samples) "
+                "VALUES(?, ?, ?, ?, ?, ?, ?, 1) "
+                "ON CONFLICT(bucket_start, identity_key) DO UPDATE SET "
+                "display_name=excluded.display_name, identity_kind=excluded.identity_kind, "
+                "confidence=excluded.confidence, "
+                "upload_bytes=traffic_minute.upload_bytes + excluded.upload_bytes, "
+                "download_bytes=traffic_minute.download_bytes + excluded.download_bytes, "
+                "samples=traffic_minute.samples + 1",
+                (
+                    bucket,
+                    identity.key,
+                    identity.label,
+                    identity.kind,
+                    identity.confidence,
+                    item["upload"],
+                    item["download"],
+                ),
+            )
+
+    def _replace_live_identities(
+        self, live: dict[str, dict[str, Any]], observed_at: int
+    ) -> None:
+        self.connection.execute("DELETE FROM live_identity")
+        for item in live.values():
+            identity = item["identity"]
+            self.connection.execute(
+                "INSERT INTO live_identity("
+                "identity_key, display_name, identity_kind, confidence, "
+                "connection_count, upload_bytes, download_bytes, observed_at) "
+                "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    identity.key,
+                    identity.label,
+                    identity.kind,
+                    identity.confidence,
+                    item["connections"],
+                    item["upload"],
+                    item["download"],
+                    observed_at,
+                ),
+            )
+
+    def _update_sample_meta(
+        self,
+        observed_at: int,
+        total_upload: int,
+        total_download: int,
+        global_upload: int | None,
+        global_download: int | None,
+    ) -> None:
+        values = {
+            "last_sample_at": observed_at,
+            "last_error": "",
+            "controller_reachable": "1",
+            "sample_count": int(self.get_meta("sample_count") or "0") + 1,
+            "last_delta_upload": total_upload,
+            "last_delta_download": total_download,
+        }
+        if global_upload is not None:
+            values["global_upload_total"] = global_upload
+        if global_download is not None:
+            values["global_download_total"] = global_download
+        for key, value in values.items():
+            self.set_meta(key, value)
+
     def record_sample(
         self,
         samples: Iterable[ConnectionSample],
@@ -140,9 +298,7 @@ class TrafficStore:
         bucket = observed_at - observed_at % 60
         deltas: dict[str, dict[str, Any]] = {}
         live: dict[str, dict[str, Any]] = {}
-        total_upload = 0
-        total_download = 0
-
+        total_upload = total_download = 0
         with self.connection:
             self.connection.execute(
                 "INSERT INTO sample_minute(bucket_start, samples) VALUES(?, 1) "
@@ -151,137 +307,24 @@ class TrafficStore:
                 (bucket,),
             )
             for sample in samples:
-                previous = self.connection.execute(
-                    "SELECT upload_bytes, download_bytes FROM connection_state "
-                    "WHERE connection_id = ?",
-                    (sample.connection_id,),
-                ).fetchone()
-                if previous is None:
-                    delta_upload = 0
-                    delta_download = 0
-                else:
-                    old_upload = int(previous[0])
-                    old_download = int(previous[1])
-                    delta_upload = (
-                        sample.upload - old_upload
-                        if sample.upload >= old_upload
-                        else sample.upload
-                    )
-                    delta_download = (
-                        sample.download - old_download
-                        if sample.download >= old_download
-                        else sample.download
-                    )
-
-                identity = sample.identity
-                if delta_upload or delta_download:
-                    item = deltas.setdefault(
-                        identity.key,
-                        {"identity": identity, "upload": 0, "download": 0},
-                    )
-                    item["upload"] += delta_upload
-                    item["download"] += delta_download
-                    total_upload += delta_upload
-                    total_download += delta_download
-
-                live_item = live.setdefault(
-                    identity.key,
-                    {
-                        "identity": identity,
-                        "connections": 0,
-                        "upload": 0,
-                        "download": 0,
-                    },
+                upload, download = self._accumulate_sample(
+                    sample, observed_at, deltas, live
                 )
-                live_item["connections"] += 1
-                live_item["upload"] += sample.upload
-                live_item["download"] += sample.download
-
-                self.connection.execute(
-                    "INSERT INTO connection_state("
-                    "connection_id, identity_key, display_name, identity_kind, "
-                    "confidence, upload_bytes, download_bytes, last_seen) "
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?) "
-                    "ON CONFLICT(connection_id) DO UPDATE SET "
-                    "identity_key=excluded.identity_key, "
-                    "display_name=excluded.display_name, "
-                    "identity_kind=excluded.identity_kind, "
-                    "confidence=excluded.confidence, "
-                    "upload_bytes=excluded.upload_bytes, "
-                    "download_bytes=excluded.download_bytes, "
-                    "last_seen=excluded.last_seen",
-                    (
-                        sample.connection_id,
-                        identity.key,
-                        identity.label,
-                        identity.kind,
-                        identity.confidence,
-                        sample.upload,
-                        sample.download,
-                        observed_at,
-                    ),
-                )
-
-            for item in deltas.values():
-                identity = item["identity"]
-                self.connection.execute(
-                    "INSERT INTO traffic_minute("
-                    "bucket_start, identity_key, display_name, identity_kind, "
-                    "confidence, upload_bytes, download_bytes, samples) "
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, 1) "
-                    "ON CONFLICT(bucket_start, identity_key) DO UPDATE SET "
-                    "display_name=excluded.display_name, "
-                    "identity_kind=excluded.identity_kind, "
-                    "confidence=excluded.confidence, "
-                    "upload_bytes=traffic_minute.upload_bytes + excluded.upload_bytes, "
-                    "download_bytes=traffic_minute.download_bytes + excluded.download_bytes, "
-                    "samples=traffic_minute.samples + 1",
-                    (
-                        bucket,
-                        identity.key,
-                        identity.label,
-                        identity.kind,
-                        identity.confidence,
-                        item["upload"],
-                        item["download"],
-                    ),
-                )
-
-            self.connection.execute("DELETE FROM live_identity")
-            for item in live.values():
-                identity = item["identity"]
-                self.connection.execute(
-                    "INSERT INTO live_identity("
-                    "identity_key, display_name, identity_kind, confidence, "
-                    "connection_count, upload_bytes, download_bytes, observed_at) "
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        identity.key,
-                        identity.label,
-                        identity.kind,
-                        identity.confidence,
-                        item["connections"],
-                        item["upload"],
-                        item["download"],
-                        observed_at,
-                    ),
-                )
-
+                total_upload += upload
+                total_download += download
+            self._upsert_traffic_deltas(bucket, deltas)
+            self._replace_live_identities(live, observed_at)
             self.connection.execute(
                 "DELETE FROM connection_state WHERE last_seen < ?",
                 (observed_at - STALE_CONNECTION_SECONDS,),
             )
-            self.set_meta("last_sample_at", observed_at)
-            self.set_meta("last_error", "")
-            self.set_meta("controller_reachable", "1")
-            self.set_meta("sample_count", int(self.get_meta("sample_count") or "0") + 1)
-            self.set_meta("last_delta_upload", total_upload)
-            self.set_meta("last_delta_download", total_download)
-            if global_upload is not None:
-                self.set_meta("global_upload_total", global_upload)
-            if global_download is not None:
-                self.set_meta("global_download_total", global_download)
-
+            self._update_sample_meta(
+                observed_at,
+                total_upload,
+                total_download,
+                global_upload,
+                global_download,
+            )
         return {
             "connections": sum(int(item["connections"]) for item in live.values()),
             "identities": len(live),
@@ -290,25 +333,21 @@ class TrafficStore:
         }
 
     @staticmethod
-    def since_value(value: str | None, now: int | None = None) -> int:
-        now = now or utc_now()
-        if not value or value == "today":
-            current = datetime_module.datetime.fromtimestamp(
-                now, datetime_module.timezone.utc
-            )
-            start = datetime_module.datetime(
+    def _today_start(now: int) -> int:
+        current = datetime_module.datetime.fromtimestamp(
+            now, datetime_module.timezone.utc
+        )
+        return int(
+            datetime_module.datetime(
                 current.year,
                 current.month,
                 current.day,
                 tzinfo=datetime_module.timezone.utc,
-            )
-            return int(start.timestamp())
-        if value in {"24h", "day"}:
-            return now - 24 * 3600
-        if value in {"7d", "week"}:
-            return now - 7 * 24 * 3600
-        if value.isdigit():
-            return now - int(value) * 3600
+            ).timestamp()
+        )
+
+    @staticmethod
+    def _iso_timestamp(value: str) -> int:
         try:
             parsed = datetime_module.datetime.fromisoformat(value.replace("Z", "+00:00"))
         except ValueError as exc:
@@ -316,6 +355,18 @@ class TrafficStore:
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=datetime_module.timezone.utc)
         return int(parsed.timestamp())
+
+    @staticmethod
+    def since_value(value: str | None, now: int | None = None) -> int:
+        now = now or utc_now()
+        if not value or value == "today":
+            return TrafficStore._today_start(now)
+        durations = {"24h": 24, "day": 24, "7d": 168, "week": 168}
+        if value in durations:
+            return now - durations[value] * 3600
+        if value.isdigit():
+            return now - int(value) * 3600
+        return TrafficStore._iso_timestamp(value)
 
     def users(self, since: int, until: int | None = None) -> list[dict[str, Any]]:
         upper = until or utc_now() + 60
@@ -338,67 +389,51 @@ class TrafficStore:
             for row in rows
         ]
 
-    def series(
-        self, since: int, until: int | None = None, step: int = 300
-    ) -> list[dict[str, Any]]:
-        upper = until or utc_now() + 60
-        traffic_rows = self.connection.execute(
+    @staticmethod
+    def _series_item(buckets: dict[int, dict[str, Any]], bucket: int) -> dict[str, Any]:
+        return buckets.setdefault(bucket, dict(EMPTY_SERIES_BUCKET))
+
+    def _traffic_series_rows(self, since: int, upper: int) -> list[sqlite3.Row]:
+        return self.connection.execute(
             "SELECT bucket_start, identity_kind, SUM(upload_bytes) AS upload, "
             "SUM(download_bytes) AS download FROM traffic_minute "
             "WHERE bucket_start >= ? AND bucket_start < ? "
             "GROUP BY bucket_start, identity_kind ORDER BY bucket_start",
             (since, upper),
         ).fetchall()
-        sample_rows = self.connection.execute(
+
+    def _sample_series_rows(self, since: int, upper: int) -> list[sqlite3.Row]:
+        return self.connection.execute(
             "SELECT bucket_start FROM sample_minute "
             "WHERE bucket_start >= ? AND bucket_start < ?",
             (since, upper),
         ).fetchall()
+
+    def series(
+        self, since: int, until: int | None = None, step: int = 300
+    ) -> list[dict[str, Any]]:
+        upper = until or utc_now() + 60
         buckets: dict[int, dict[str, Any]] = {}
-        for row in traffic_rows:
-            bucket = int(row["bucket_start"]) // step * step
-            item = buckets.setdefault(
-                bucket,
-                {
-                    "upload": 0,
-                    "download": 0,
-                    "attributed": 0,
-                    "unattributed": 0,
-                    "sampled": False,
-                },
+        for row in self._traffic_series_rows(since, upper):
+            item = self._series_item(
+                buckets, int(row["bucket_start"]) // step * step
             )
             upload = int(row["upload"] or 0)
             download = int(row["download"] or 0)
             item["upload"] += upload
             item["download"] += download
-            if row["identity_kind"] == "unknown":
-                item["unattributed"] += upload + download
-            else:
-                item["attributed"] += upload + download
-        for row in sample_rows:
-            bucket = int(row["bucket_start"]) // step * step
-            item = buckets.setdefault(
-                bucket,
-                {
-                    "upload": 0,
-                    "download": 0,
-                    "attributed": 0,
-                    "unattributed": 0,
-                    "sampled": False,
-                },
+            attribution = (
+                "unattributed" if row["identity_kind"] == "unknown" else "attributed"
             )
-            item["sampled"] = True
+            item[attribution] += upload + download
+        for row in self._sample_series_rows(since, upper):
+            self._series_item(
+                buckets, int(row["bucket_start"]) // step * step
+            )["sampled"] = True
         first = since // step * step
         last = (upper - 1) // step * step
-        empty = {
-            "upload": 0,
-            "download": 0,
-            "attributed": 0,
-            "unattributed": 0,
-            "sampled": False,
-        }
         return [
-            {"timestamp": bucket, **buckets.get(bucket, empty)}
+            {"timestamp": bucket, **buckets.get(bucket, EMPTY_SERIES_BUCKET)}
             for bucket in range(first, last + 1, step)
         ]
 
@@ -419,16 +454,25 @@ class TrafficStore:
             for row in rows
         ]
 
-    def summary(self, since: int) -> dict[str, Any]:
-        users = self.users(since)
-        upload = sum(int(item["upload"] or 0) for item in users)
-        download = sum(int(item["download"] or 0) for item in users)
-        attributed = sum(
+    @staticmethod
+    def _summed_bytes(users: list[dict[str, Any]], field: str) -> int:
+        return sum(int(item[field] or 0) for item in users)
+
+    @staticmethod
+    def _attributed_bytes(users: list[dict[str, Any]]) -> int:
+        return sum(
             int(item["upload"] or 0) + int(item["download"] or 0)
             for item in users
             if item["identity_kind"] != "unknown"
         )
+
+    def summary(self, since: int) -> dict[str, Any]:
+        users = self.users(since)
+        upload = self._summed_bytes(users, "upload")
+        download = self._summed_bytes(users, "download")
+        attributed = self._attributed_bytes(users)
         total = upload + download
+        attribution_percent = round(attributed * 100 / total, 1) if total else 100.0
         return {
             "since": format_utc(since),
             "upload": upload,
@@ -438,7 +482,7 @@ class TrafficStore:
             "tracked_identities": len(users),
             "attributed": attributed,
             "unattributed": max(0, total - attributed),
-            "attribution_percent": round(attributed * 100 / total, 1) if total else 100.0,
+            "attribution_percent": attribution_percent,
             "sample_count": int(self.get_meta("sample_count") or "0"),
             "last_sample_at": format_utc(self.get_meta("last_sample_at")),
             "controller_reachable": self.get_meta("controller_reachable") == "1",

--- a/scripts/traffic/store.py
+++ b/scripts/traffic/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as datetime_module
 import os
 import sqlite3
+import stat
 import time
 from pathlib import Path
 from typing import Any, Iterable
@@ -98,8 +99,8 @@ class TrafficStore:
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
         try:
-            # The state directory is intentionally accessible only by its owner.
-            os.chmod(self.path.parent, 0o700)  # nosec B103
+            # Owner-only access: read, write, and directory traversal.
+            os.chmod(self.path.parent, stat.S_IRWXU)
         except OSError:
             pass
         self.connection = sqlite3.connect(self.path, timeout=30)

--- a/scripts/traffic/store.py
+++ b/scripts/traffic/store.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""SQLite persistence and aggregation for sampled traffic telemetry."""
+from __future__ import annotations
+
+import datetime as datetime_module
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+from model import ConnectionSample
+
+STALE_CONNECTION_SECONDS = 180
+
+
+def utc_now() -> int:
+    return int(time.time())
+
+
+def format_utc(timestamp: int | float | str | None) -> str | None:
+    if timestamp is None:
+        return None
+    return datetime_module.datetime.fromtimestamp(
+        float(timestamp), datetime_module.timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+
+
+def linux_user_id(identity_key: str, identity_kind: str) -> int | None:
+    """Return the numeric Linux UID, never a generic identity string."""
+    if identity_kind != "linux-user" or not identity_key.startswith("uid:"):
+        return None
+    try:
+        uid = int(identity_key.removeprefix("uid:"))
+    except ValueError:
+        return None
+    return uid if uid >= 0 else None
+
+
+class TrafficStore:
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self.path.parent, 0o700)
+        except OSError:
+            pass
+        self.connection = sqlite3.connect(self.path, timeout=30)
+        self.connection.row_factory = sqlite3.Row
+        self.connection.execute("PRAGMA journal_mode=WAL")
+        self.connection.execute("PRAGMA synchronous=NORMAL")
+        self._create_schema()
+        try:
+            os.chmod(self.path, 0o600)
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        self.connection.close()
+
+    def _create_schema(self) -> None:
+        self.connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS traffic_minute (
+                bucket_start INTEGER NOT NULL,
+                identity_key TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                identity_kind TEXT NOT NULL,
+                confidence TEXT NOT NULL,
+                upload_bytes INTEGER NOT NULL DEFAULT 0,
+                download_bytes INTEGER NOT NULL DEFAULT 0,
+                samples INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (bucket_start, identity_key)
+            );
+            CREATE INDEX IF NOT EXISTS idx_traffic_minute_bucket
+                ON traffic_minute(bucket_start);
+
+            CREATE TABLE IF NOT EXISTS sample_minute (
+                bucket_start INTEGER PRIMARY KEY,
+                samples INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS connection_state (
+                connection_id TEXT PRIMARY KEY,
+                identity_key TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                identity_kind TEXT NOT NULL,
+                confidence TEXT NOT NULL,
+                upload_bytes INTEGER NOT NULL,
+                download_bytes INTEGER NOT NULL,
+                last_seen INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_connection_state_last_seen
+                ON connection_state(last_seen);
+
+            CREATE TABLE IF NOT EXISTS live_identity (
+                identity_key TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                identity_kind TEXT NOT NULL,
+                confidence TEXT NOT NULL,
+                connection_count INTEGER NOT NULL,
+                upload_bytes INTEGER NOT NULL,
+                download_bytes INTEGER NOT NULL,
+                observed_at INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS collector_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            """
+        )
+        self.connection.commit()
+
+    def set_meta(self, key: str, value: Any) -> None:
+        self.connection.execute(
+            "INSERT INTO collector_meta(key, value) VALUES(?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, str(value)),
+        )
+
+    def get_meta(self, key: str) -> str | None:
+        row = self.connection.execute(
+            "SELECT value FROM collector_meta WHERE key = ?", (key,)
+        ).fetchone()
+        return str(row[0]) if row else None
+
+    def record_error(self, message: str) -> None:
+        self.set_meta("last_error", message[:300])
+        self.set_meta("controller_reachable", "0")
+        self.connection.commit()
+
+    def record_sample(
+        self,
+        samples: Iterable[ConnectionSample],
+        observed_at: int,
+        global_upload: int | None = None,
+        global_download: int | None = None,
+    ) -> dict[str, int]:
+        bucket = observed_at - observed_at % 60
+        deltas: dict[str, dict[str, Any]] = {}
+        live: dict[str, dict[str, Any]] = {}
+        total_upload = 0
+        total_download = 0
+
+        with self.connection:
+            self.connection.execute(
+                "INSERT INTO sample_minute(bucket_start, samples) VALUES(?, 1) "
+                "ON CONFLICT(bucket_start) DO UPDATE SET "
+                "samples=sample_minute.samples + 1",
+                (bucket,),
+            )
+            for sample in samples:
+                previous = self.connection.execute(
+                    "SELECT upload_bytes, download_bytes FROM connection_state "
+                    "WHERE connection_id = ?",
+                    (sample.connection_id,),
+                ).fetchone()
+                if previous is None:
+                    delta_upload = 0
+                    delta_download = 0
+                else:
+                    old_upload = int(previous[0])
+                    old_download = int(previous[1])
+                    delta_upload = (
+                        sample.upload - old_upload
+                        if sample.upload >= old_upload
+                        else sample.upload
+                    )
+                    delta_download = (
+                        sample.download - old_download
+                        if sample.download >= old_download
+                        else sample.download
+                    )
+
+                identity = sample.identity
+                if delta_upload or delta_download:
+                    item = deltas.setdefault(
+                        identity.key,
+                        {"identity": identity, "upload": 0, "download": 0},
+                    )
+                    item["upload"] += delta_upload
+                    item["download"] += delta_download
+                    total_upload += delta_upload
+                    total_download += delta_download
+
+                live_item = live.setdefault(
+                    identity.key,
+                    {
+                        "identity": identity,
+                        "connections": 0,
+                        "upload": 0,
+                        "download": 0,
+                    },
+                )
+                live_item["connections"] += 1
+                live_item["upload"] += sample.upload
+                live_item["download"] += sample.download
+
+                self.connection.execute(
+                    "INSERT INTO connection_state("
+                    "connection_id, identity_key, display_name, identity_kind, "
+                    "confidence, upload_bytes, download_bytes, last_seen) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(connection_id) DO UPDATE SET "
+                    "identity_key=excluded.identity_key, "
+                    "display_name=excluded.display_name, "
+                    "identity_kind=excluded.identity_kind, "
+                    "confidence=excluded.confidence, "
+                    "upload_bytes=excluded.upload_bytes, "
+                    "download_bytes=excluded.download_bytes, "
+                    "last_seen=excluded.last_seen",
+                    (
+                        sample.connection_id,
+                        identity.key,
+                        identity.label,
+                        identity.kind,
+                        identity.confidence,
+                        sample.upload,
+                        sample.download,
+                        observed_at,
+                    ),
+                )
+
+            for item in deltas.values():
+                identity = item["identity"]
+                self.connection.execute(
+                    "INSERT INTO traffic_minute("
+                    "bucket_start, identity_key, display_name, identity_kind, "
+                    "confidence, upload_bytes, download_bytes, samples) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, 1) "
+                    "ON CONFLICT(bucket_start, identity_key) DO UPDATE SET "
+                    "display_name=excluded.display_name, "
+                    "identity_kind=excluded.identity_kind, "
+                    "confidence=excluded.confidence, "
+                    "upload_bytes=traffic_minute.upload_bytes + excluded.upload_bytes, "
+                    "download_bytes=traffic_minute.download_bytes + excluded.download_bytes, "
+                    "samples=traffic_minute.samples + 1",
+                    (
+                        bucket,
+                        identity.key,
+                        identity.label,
+                        identity.kind,
+                        identity.confidence,
+                        item["upload"],
+                        item["download"],
+                    ),
+                )
+
+            self.connection.execute("DELETE FROM live_identity")
+            for item in live.values():
+                identity = item["identity"]
+                self.connection.execute(
+                    "INSERT INTO live_identity("
+                    "identity_key, display_name, identity_kind, confidence, "
+                    "connection_count, upload_bytes, download_bytes, observed_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        identity.key,
+                        identity.label,
+                        identity.kind,
+                        identity.confidence,
+                        item["connections"],
+                        item["upload"],
+                        item["download"],
+                        observed_at,
+                    ),
+                )
+
+            self.connection.execute(
+                "DELETE FROM connection_state WHERE last_seen < ?",
+                (observed_at - STALE_CONNECTION_SECONDS,),
+            )
+            self.set_meta("last_sample_at", observed_at)
+            self.set_meta("last_error", "")
+            self.set_meta("controller_reachable", "1")
+            self.set_meta("sample_count", int(self.get_meta("sample_count") or "0") + 1)
+            self.set_meta("last_delta_upload", total_upload)
+            self.set_meta("last_delta_download", total_download)
+            if global_upload is not None:
+                self.set_meta("global_upload_total", global_upload)
+            if global_download is not None:
+                self.set_meta("global_download_total", global_download)
+
+        return {
+            "connections": sum(int(item["connections"]) for item in live.values()),
+            "identities": len(live),
+            "upload": total_upload,
+            "download": total_download,
+        }
+
+    @staticmethod
+    def since_value(value: str | None, now: int | None = None) -> int:
+        now = now or utc_now()
+        if not value or value == "today":
+            current = datetime_module.datetime.fromtimestamp(
+                now, datetime_module.timezone.utc
+            )
+            start = datetime_module.datetime(
+                current.year,
+                current.month,
+                current.day,
+                tzinfo=datetime_module.timezone.utc,
+            )
+            return int(start.timestamp())
+        if value in {"24h", "day"}:
+            return now - 24 * 3600
+        if value in {"7d", "week"}:
+            return now - 7 * 24 * 3600
+        if value.isdigit():
+            return now - int(value) * 3600
+        try:
+            parsed = datetime_module.datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"无法解析时间范围：{value}") from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=datetime_module.timezone.utc)
+        return int(parsed.timestamp())
+
+    def users(self, since: int, until: int | None = None) -> list[dict[str, Any]]:
+        upper = until or utc_now() + 60
+        rows = self.connection.execute(
+            "SELECT identity_key, display_name, identity_kind, confidence, "
+            "SUM(upload_bytes) AS upload, SUM(download_bytes) AS download, "
+            "SUM(samples) AS samples FROM traffic_minute "
+            "WHERE bucket_start >= ? AND bucket_start < ? "
+            "GROUP BY identity_key, display_name, identity_kind, confidence "
+            "ORDER BY (SUM(upload_bytes) + SUM(download_bytes)) DESC",
+            (since, upper),
+        ).fetchall()
+        return [
+            {
+                **dict(row),
+                "user_id": linux_user_id(
+                    str(row["identity_key"]), str(row["identity_kind"])
+                ),
+            }
+            for row in rows
+        ]
+
+    def series(
+        self, since: int, until: int | None = None, step: int = 300
+    ) -> list[dict[str, Any]]:
+        upper = until or utc_now() + 60
+        traffic_rows = self.connection.execute(
+            "SELECT bucket_start, identity_kind, SUM(upload_bytes) AS upload, "
+            "SUM(download_bytes) AS download FROM traffic_minute "
+            "WHERE bucket_start >= ? AND bucket_start < ? "
+            "GROUP BY bucket_start, identity_kind ORDER BY bucket_start",
+            (since, upper),
+        ).fetchall()
+        sample_rows = self.connection.execute(
+            "SELECT bucket_start FROM sample_minute "
+            "WHERE bucket_start >= ? AND bucket_start < ?",
+            (since, upper),
+        ).fetchall()
+        buckets: dict[int, dict[str, Any]] = {}
+        for row in traffic_rows:
+            bucket = int(row["bucket_start"]) // step * step
+            item = buckets.setdefault(
+                bucket,
+                {
+                    "upload": 0,
+                    "download": 0,
+                    "attributed": 0,
+                    "unattributed": 0,
+                    "sampled": False,
+                },
+            )
+            upload = int(row["upload"] or 0)
+            download = int(row["download"] or 0)
+            item["upload"] += upload
+            item["download"] += download
+            if row["identity_kind"] == "unknown":
+                item["unattributed"] += upload + download
+            else:
+                item["attributed"] += upload + download
+        for row in sample_rows:
+            bucket = int(row["bucket_start"]) // step * step
+            item = buckets.setdefault(
+                bucket,
+                {
+                    "upload": 0,
+                    "download": 0,
+                    "attributed": 0,
+                    "unattributed": 0,
+                    "sampled": False,
+                },
+            )
+            item["sampled"] = True
+        first = since // step * step
+        last = (upper - 1) // step * step
+        empty = {
+            "upload": 0,
+            "download": 0,
+            "attributed": 0,
+            "unattributed": 0,
+            "sampled": False,
+        }
+        return [
+            {"timestamp": bucket, **buckets.get(bucket, empty)}
+            for bucket in range(first, last + 1, step)
+        ]
+
+    def live(self) -> list[dict[str, Any]]:
+        rows = self.connection.execute(
+            "SELECT identity_key, display_name, identity_kind, confidence, "
+            "connection_count, upload_bytes, download_bytes, observed_at "
+            "FROM live_identity ORDER BY (upload_bytes + download_bytes) DESC"
+        ).fetchall()
+        return [
+            {
+                **dict(row),
+                "user_id": linux_user_id(
+                    str(row["identity_key"]), str(row["identity_kind"])
+                ),
+                "observed_at": format_utc(row["observed_at"]),
+            }
+            for row in rows
+        ]
+
+    def summary(self, since: int) -> dict[str, Any]:
+        users = self.users(since)
+        upload = sum(int(item["upload"] or 0) for item in users)
+        download = sum(int(item["download"] or 0) for item in users)
+        attributed = sum(
+            int(item["upload"] or 0) + int(item["download"] or 0)
+            for item in users
+            if item["identity_kind"] != "unknown"
+        )
+        total = upload + download
+        return {
+            "since": format_utc(since),
+            "upload": upload,
+            "download": download,
+            "total": total,
+            "active_identities": len(self.live()),
+            "tracked_identities": len(users),
+            "attributed": attributed,
+            "unattributed": max(0, total - attributed),
+            "attribution_percent": round(attributed * 100 / total, 1) if total else 100.0,
+            "sample_count": int(self.get_meta("sample_count") or "0"),
+            "last_sample_at": format_utc(self.get_meta("last_sample_at")),
+            "controller_reachable": self.get_meta("controller_reachable") == "1",
+            "last_error": self.get_meta("last_error") or None,
+            "users": users,
+        }

--- a/scripts/traffic/traffic.py
+++ b/scripts/traffic/traffic.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""CLI entry point for clashctl traffic accounting and dashboard."""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+from collector import TrafficError, acquire_pid_file, is_running, remove_pid_file, stop_collector
+from server import DashboardServer, load_dashboard
+from store import TrafficStore, format_utc, linux_user_id, utc_now
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+DEFAULT_INTERVAL = 5.0
+
+
+def state_dir_from_arg(value: str | None) -> Path:
+    if value:
+        return Path(value).expanduser()
+    root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    return root / "clashctl"
+
+
+def bytes_label(value: int) -> str:
+    units = ("B", "KB", "MB", "GB", "TB")
+    amount = float(value)
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            return f"{amount:.1f} {unit}" if unit != "B" else f"{int(value)} B"
+        amount /= 1024
+    return f"{int(value)} B"
+
+
+def serve(args: argparse.Namespace) -> int:
+    state_dir = state_dir_from_arg(args.state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    acquire_pid_file(state_dir)
+    store: TrafficStore | None = None
+    server: DashboardServer | None = None
+    stop_requested = False
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stop_requested
+        stop_requested = True
+
+    try:
+        store = TrafficStore(state_dir / "traffic.sqlite3")
+        signal.signal(signal.SIGTERM, request_stop)
+        signal.signal(signal.SIGINT, request_stop)
+        server = DashboardServer(
+            (args.host, int(args.port)),
+            store,
+            load_dashboard(Path(__file__)),
+            max(1.0, float(args.interval)),
+        )
+        server.timeout = 0.25
+        from collector import collect_once, runtime_connection_config
+
+        config_path = Path(args.config_path).expanduser()
+        next_sample = 0.0
+        while not stop_requested:
+            now = time.monotonic()
+            if now >= next_sample:
+                try:
+                    controller, secret = runtime_connection_config(config_path)
+                    collect_once(store, controller, secret)
+                except TrafficError as exc:
+                    store.record_error(str(exc))
+                next_sample = now + server.interval
+            server.handle_request()
+    finally:
+        if server is not None:
+            server.server_close()
+        if store is not None:
+            store.close()
+        remove_pid_file(state_dir)
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    state_dir = state_dir_from_arg(args.state_dir)
+    running, pid = is_running(state_dir)
+    store_path = state_dir / "traffic.sqlite3"
+    if running:
+        print(f"collector=running pid={pid} state={store_path}")
+        return 0
+    print(f"collector=stopped state={store_path}")
+    return 1
+
+
+def command_stop(args: argparse.Namespace) -> int:
+    stopped = stop_collector(state_dir_from_arg(args.state_dir))
+    print("collector=stopping" if stopped else "collector=stopped")
+    return 0
+
+
+def report(args: argparse.Namespace) -> int:
+    store = TrafficStore(state_dir_from_arg(args.state_dir) / "traffic.sqlite3")
+    try:
+        since = store.since_value(args.since)
+        rows = store.users(since)
+        print(f"范围：{format_utc(since)} → now")
+        print("Linux UID    身份                 合计       置信度")
+        print("-" * 68)
+        for row in rows[: args.limit]:
+            upload = int(row["upload"] or 0)
+            download = int(row["download"] or 0)
+            user_id = "—" if row["user_id"] is None else str(row["user_id"])
+            print(
+                f"{user_id:<13}"
+                f"{row['display_name'][:19]:<21}"
+                f"{bytes_label(upload + download):<12}"
+                f"{row['confidence']}"
+            )
+        if not rows:
+            print("暂无采样数据。先运行：clashctl traffic start")
+        return 0
+    finally:
+        store.close()
+
+
+def live_report(args: argparse.Namespace) -> int:
+    store = TrafficStore(state_dir_from_arg(args.state_dir) / "traffic.sqlite3")
+    try:
+        rows = store.live()
+        print("Linux UID    身份                 连接     当前流量       置信度")
+        print("-" * 76)
+        for row in rows:
+            current = int(row["upload_bytes"]) + int(row["download_bytes"])
+            user_id = "—" if row["user_id"] is None else str(row["user_id"])
+            print(
+                f"{user_id:<13}"
+                f"{row['display_name'][:19]:<21}"
+                f"{int(row['connection_count']):<9}"
+                f"{bytes_label(current):<15}"
+                f"{row['confidence']}"
+            )
+        if not rows:
+            print("当前没有活跃连接，或采集器尚未成功连接 Mihomo。")
+        return 0
+    finally:
+        store.close()
+
+
+def export_csv(args: argparse.Namespace) -> int:
+    store = TrafficStore(state_dir_from_arg(args.state_dir) / "traffic.sqlite3")
+    try:
+        since = store.since_value(args.since)
+        until = store.since_value(args.until) if args.until else utc_now() + 60
+        writer = csv.writer(sys.stdout)
+        writer.writerow(
+            [
+                "bucket_start_utc",
+                "user_id",
+                "identity",
+                "identity_kind",
+                "confidence",
+                "upload_bytes",
+                "download_bytes",
+                "total_bytes",
+                "samples",
+            ]
+        )
+        rows = store.connection.execute(
+            "SELECT bucket_start, identity_key, display_name, identity_kind, "
+            "confidence, upload_bytes, download_bytes, samples FROM traffic_minute "
+            "WHERE bucket_start >= ? AND bucket_start < ? "
+            "ORDER BY bucket_start, (upload_bytes + download_bytes) DESC",
+            (since, until),
+        ).fetchall()
+        for row in rows:
+            upload = int(row["upload_bytes"])
+            download = int(row["download_bytes"])
+            writer.writerow(
+                [
+                    format_utc(row["bucket_start"]),
+                    linux_user_id(row["identity_key"], row["identity_kind"]),
+                    row["display_name"],
+                    row["identity_kind"],
+                    row["confidence"],
+                    upload,
+                    download,
+                    upload + download,
+                    row["samples"],
+                ]
+            )
+        return 0
+    finally:
+        store.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="traffic.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    serve_parser = sub.add_parser("serve")
+    serve_parser.add_argument("--config-path", required=True)
+    serve_parser.add_argument("--state-dir")
+    serve_parser.add_argument("--host", default=DEFAULT_HOST)
+    serve_parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    serve_parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL)
+    serve_parser.set_defaults(func=serve)
+
+    status_parser = sub.add_parser("status")
+    status_parser.add_argument("--state-dir")
+    status_parser.set_defaults(func=command_status)
+
+    stop_parser = sub.add_parser("stop")
+    stop_parser.add_argument("--state-dir")
+    stop_parser.set_defaults(func=command_stop)
+
+    report_parser = sub.add_parser("report")
+    report_parser.add_argument("--state-dir")
+    report_parser.add_argument("--since", default="today")
+    report_parser.add_argument("--limit", type=int, default=50)
+    report_parser.set_defaults(func=report)
+
+    live_parser = sub.add_parser("live")
+    live_parser.add_argument("--state-dir")
+    live_parser.set_defaults(func=live_report)
+
+    export_parser = sub.add_parser("export")
+    export_parser.add_argument("--state-dir")
+    export_parser.add_argument("--since", default="today")
+    export_parser.add_argument("--until")
+    export_parser.set_defaults(func=export_csv)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (TrafficError, ValueError) as exc:
+        print(f"clashctl traffic: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -1,0 +1,881 @@
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+from unittest import mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TRAFFIC_DIR = ROOT / "scripts" / "traffic"
+sys.path.insert(0, str(TRAFFIC_DIR))
+
+from model import ConnectionSample, Identity, identify_connection  # noqa: E402
+from server import DashboardServer  # noqa: E402
+from store import TrafficStore, format_utc  # noqa: E402
+import traffic as traffic_cli  # noqa: E402
+
+
+class IdentityTests(unittest.TestCase):
+    def test_identity_precedence_prefers_authenticated_user(self) -> None:
+        identity = identify_connection(
+            {"inboundUser": "alice", "uid": 1000, "sourceIP": "10.0.0.8"}
+        )
+        self.assertEqual(identity.key, "account:alice")
+        self.assertEqual(identity.confidence, "high")
+
+    def test_uid_zero_falls_back_to_source_ip(self) -> None:
+        identity = identify_connection({"uid": 0, "sourceIP": "127.0.0.1"})
+        self.assertEqual(identity.key, "source-ip:127.0.0.1")
+        self.assertEqual(identity.confidence, "low")
+
+    def test_uid_zero_without_source_is_unattributed(self) -> None:
+        identity = identify_connection({"uid": 0})
+        self.assertEqual(identity.key, "unknown")
+
+
+class StoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TrafficStore(Path(self.temp_dir.name) / "traffic.sqlite3")
+        self.alice = Identity("account:alice", "alice", "account", "high")
+
+    def tearDown(self) -> None:
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def sample(self, upload: int, download: int) -> ConnectionSample:
+        return ConnectionSample("conn-1", self.alice, upload, download)
+
+    def test_first_sample_is_baseline_and_second_records_only_delta(self) -> None:
+        self.store.record_sample([self.sample(100, 500)], 1_700_000_000)
+        self.assertEqual(self.store.users(1_699_999_900), [])
+
+        result = self.store.record_sample([self.sample(180, 760)], 1_700_000_005)
+        self.assertEqual(result["upload"], 80)
+        self.assertEqual(result["download"], 260)
+        users = self.store.users(1_699_999_900, 1_700_000_100)
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0]["upload"], 80)
+        self.assertEqual(users[0]["download"], 260)
+
+    def test_counter_reset_counts_new_counter_value(self) -> None:
+        self.store.record_sample([self.sample(100, 500)], 1_700_000_000)
+        result = self.store.record_sample([self.sample(10, 20)], 1_700_000_005)
+        self.assertEqual(result["upload"], 10)
+        self.assertEqual(result["download"], 20)
+
+    def test_database_does_not_store_destination_or_process_fields(self) -> None:
+        columns = {
+            row[1]
+            for table in ("traffic_minute", "connection_state", "live_identity")
+            for row in self.store.connection.execute(f"PRAGMA table_info({table})")
+        }
+        forbidden = {"host", "destination", "process", "process_path", "source_port"}
+        self.assertTrue(columns.isdisjoint(forbidden))
+
+
+class DashboardServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TrafficStore(Path(self.temp_dir.name) / "traffic.sqlite3")
+        identity = Identity("account:alice", "alice", "account", "high")
+        observed_at = int(time.time())
+        self.store.record_sample(
+            [ConnectionSample("conn", identity, 100, 200)], observed_at
+        )
+        self.store.record_sample(
+            [ConnectionSample("conn", identity, 150, 350)], observed_at + 5
+        )
+        self.server = DashboardServer(
+            ("127.0.0.1", 0), self.store, b"<html>ok</html>", 5.0
+        )
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.server_close()
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def request(self, path: str):
+        result = {}
+        error = {}
+
+        def client() -> None:
+            try:
+                result["response"] = urllib.request.urlopen(
+                    self.base_url + path, timeout=2
+                )
+            except Exception as exc:  # re-raised in the test thread
+                error["exception"] = exc
+
+        thread = threading.Thread(target=client)
+        thread.start()
+        self.server.handle_request()
+        thread.join(timeout=2)
+        if "exception" in error:
+            raise error["exception"]
+        return result["response"]
+
+    def test_summary_api_can_query_sqlite(self) -> None:
+        with self.request("/api/summary?since=7d") as response:
+            payload = json.load(response)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(payload["total"], 200)
+        self.assertEqual(payload["users"][0]["display_name"], "alice")
+        self.assertIsNone(payload["users"][0]["user_id"])
+
+    def test_security_header_is_not_duplicated(self) -> None:
+        with self.request("/") as response:
+            values = response.headers.get_all("X-Content-Type-Options")
+        self.assertEqual(values, ["nosniff"])
+
+
+class AdditionalStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TrafficStore(Path(self.temp_dir.name) / "traffic.sqlite3")
+
+    def tearDown(self) -> None:
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def test_multiple_connections_are_aggregated_by_identity(self) -> None:
+        identity = Identity("account:alice", "alice", "account", "high")
+        first = [
+            ConnectionSample("one", identity, 10, 20),
+            ConnectionSample("two", identity, 30, 40),
+        ]
+        second = [
+            ConnectionSample("one", identity, 20, 50),
+            ConnectionSample("two", identity, 60, 100),
+        ]
+        self.store.record_sample(first, 1_700_000_000)
+        self.store.record_sample(second, 1_700_000_005)
+        users = self.store.users(1_699_999_900, 1_700_000_100)
+        self.assertEqual(users[0]["upload"], 40)
+        self.assertEqual(users[0]["download"], 90)
+        live = self.store.live()[0]
+        self.assertEqual(live["connection_count"], 2)
+        self.assertIsNone(live["user_id"])
+
+    def test_stale_connection_state_is_removed(self) -> None:
+        identity = Identity("account:alice", "alice", "account", "high")
+        self.store.record_sample(
+            [ConnectionSample("stale", identity, 1, 1)], 1_700_000_000
+        )
+        self.store.record_sample([], 1_700_000_181)
+        count = self.store.connection.execute(
+            "SELECT COUNT(*) FROM connection_state"
+        ).fetchone()[0]
+        self.assertEqual(count, 0)
+        self.assertEqual(self.store.live(), [])
+
+    def test_summary_reports_attribution_coverage(self) -> None:
+        known = Identity("account:alice", "alice", "account", "high")
+        unknown = Identity("unknown", "Unattributed", "unknown", "low")
+        self.store.record_sample(
+            [
+                ConnectionSample("known", known, 0, 0),
+                ConnectionSample("unknown", unknown, 0, 0),
+            ],
+            1_700_000_000,
+        )
+        self.store.record_sample(
+            [
+                ConnectionSample("known", known, 25, 75),
+                ConnectionSample("unknown", unknown, 20, 80),
+            ],
+            1_700_000_005,
+        )
+        summary = self.store.summary(1_699_999_900)
+        self.assertEqual(summary["total"], 200)
+        self.assertEqual(summary["attribution_percent"], 50.0)
+
+
+class CollectorTests(unittest.TestCase):
+    def test_runtime_config_reads_only_top_level_controller_and_secret(self) -> None:
+        from collector import runtime_connection_config
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "runtime.yaml"
+            path.write_text(
+                "external-controller: '0.0.0.0:9090'\n"
+                "secret: \"safe-secret\"\n"
+                "proxy-groups:\n"
+                "  - secret: nested-value\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                runtime_connection_config(path), ("0.0.0.0:9090", "safe-secret")
+            )
+
+    def test_wildcard_controller_is_forced_to_loopback(self) -> None:
+        from collector import controller_address
+
+        self.assertEqual(controller_address("0.0.0.0:9090"), "127.0.0.1:9090")
+        self.assertEqual(controller_address("[::]:9091"), "127.0.0.1:9091")
+
+    def test_collect_once_reads_mihomo_payload_and_never_persists_destination(self) -> None:
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from collector import collect_once
+
+        payloads = [
+            {
+                "uploadTotal": 100,
+                "downloadTotal": 200,
+                "connections": [
+                    {
+                        "id": "connection-1",
+                        "upload": 10,
+                        "download": 20,
+                        "metadata": {
+                            "inboundUser": "alice",
+                            "host": "private.example",
+                            "processPath": "/sensitive/process",
+                        },
+                    }
+                ],
+            },
+            {
+                "uploadTotal": 150,
+                "downloadTotal": 280,
+                "connections": [
+                    {
+                        "id": "connection-1",
+                        "upload": 30,
+                        "download": 70,
+                        "metadata": {
+                            "inboundUser": "alice",
+                            "host": "private.example",
+                            "processPath": "/sensitive/process",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format, *_args):
+                return
+
+            def do_GET(self):  # noqa: N802
+                body = json.dumps(payloads.pop(0)).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                store = TrafficStore(Path(directory) / "traffic.sqlite3")
+                address = f"127.0.0.1:{server.server_port}"
+                collect_once(store, address, "")
+                result = collect_once(store, address, "")
+                self.assertEqual(result["upload"], 20)
+                self.assertEqual(result["download"], 50)
+                dump = "\n".join(
+                    row[0]
+                    for row in store.connection.execute(
+                        "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"
+                    )
+                )
+                rows = repr(store.connection.execute("SELECT * FROM connection_state").fetchall())
+                self.assertNotIn("private.example", dump + rows)
+                self.assertNotIn("/sensitive/process", dump + rows)
+                store.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+class CliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import subprocess
+
+        self.subprocess = subprocess
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.state_dir = Path(self.temp_dir.name) / "state"
+        store = TrafficStore(self.state_dir / "traffic.sqlite3")
+        now = int(time.time())
+        identity = Identity("account:alice", "alice", "account", "high")
+        store.record_sample([ConnectionSample("c", identity, 0, 0)], now)
+        store.record_sample([ConnectionSample("c", identity, 1024, 2048)], now + 1)
+        store.close()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_cli(self, *args: str):
+        return self.subprocess.run(
+            [sys.executable, str(TRAFFIC_DIR / "traffic.py"), *args],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_report_prints_identity_and_totals(self) -> None:
+        result = self.run_cli(
+            "report", "--state-dir", str(self.state_dir), "--since", "24h"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("alice", result.stdout)
+        self.assertIn("3.0 KB", result.stdout)
+
+    def test_export_writes_machine_readable_csv(self) -> None:
+        result = self.run_cli(
+            "export", "--state-dir", str(self.state_dir), "--since", "24h"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "bucket_start_utc,user_id,identity,identity_kind", result.stdout
+        )
+        self.assertIn(
+            ",,alice,account,high,1024,2048,3072,",
+            result.stdout,
+        )
+
+
+class SamplingPresenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TrafficStore(Path(self.temp_dir.name) / "traffic.sqlite3")
+
+    def tearDown(self) -> None:
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def test_series_distinguishes_sampled_zero_from_missing_interval(self) -> None:
+        identity = Identity("account:alice", "alice", "account", "high")
+        start = 1_700_000_000
+        self.store.record_sample([ConnectionSample("c", identity, 0, 0)], start)
+        series = self.store.series(start - start % 300, start - start % 300 + 600)
+        sampled = [point for point in series if point["sampled"]]
+        missing = [point for point in series if not point["sampled"]]
+        self.assertEqual(len(sampled), 1)
+        self.assertEqual(sampled[0]["upload"] + sampled[0]["download"], 0)
+        self.assertEqual(len(missing), 1)
+
+    def test_failed_controller_read_does_not_mark_interval_sampled(self) -> None:
+        self.store.record_error("unreachable")
+        start = 1_700_000_000
+        series = self.store.series(start - start % 300, start - start % 300 + 300)
+        self.assertFalse(series[0]["sampled"])
+
+
+class ProcessLifecycleTests(unittest.TestCase):
+    def test_bind_failure_removes_pid_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_dir = root / "state"
+            config_path = root / "runtime.yaml"
+            config_path.write_text(
+                "external-controller: 127.0.0.1:9\nsecret: ''\n",
+                encoding="utf-8",
+            )
+            blocker = socket.socket()
+            blocker.bind(("127.0.0.1", 0))
+            blocker.listen(1)
+            port = blocker.getsockname()[1]
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(TRAFFIC_DIR / "traffic.py"),
+                        "serve",
+                        "--config-path",
+                        str(config_path),
+                        "--state-dir",
+                        str(state_dir),
+                        "--port",
+                        str(port),
+                    ],
+                    text=True,
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
+            finally:
+                blocker.close()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse((state_dir / "traffic.pid").exists())
+
+    def test_real_process_health_sampling_and_stop(self) -> None:
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        counter = {"value": 0}
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, _format, *_args):
+                return
+
+            def do_GET(self):  # noqa: N802
+                counter["value"] += 1
+                value = counter["value"] * 1024
+                body = json.dumps(
+                    {
+                        "uploadTotal": value,
+                        "downloadTotal": value * 2,
+                        "connections": [
+                            {
+                                "id": "live-connection",
+                                "upload": value,
+                                "download": value * 2,
+                                "metadata": {"inboundUser": "alice"},
+                            }
+                        ],
+                    }
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        controller = HTTPServer(("127.0.0.1", 0), Handler)
+        controller_thread = threading.Thread(
+            target=controller.serve_forever, daemon=True
+        )
+        controller_thread.start()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_dir = root / "state"
+            config_path = root / "runtime.yaml"
+            config_path.write_text(
+                f"external-controller: 127.0.0.1:{controller.server_port}\n"
+                "secret: ''\n",
+                encoding="utf-8",
+            )
+            dashboard_socket = socket.socket()
+            dashboard_socket.bind(("127.0.0.1", 0))
+            dashboard_port = dashboard_socket.getsockname()[1]
+            dashboard_socket.close()
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(TRAFFIC_DIR / "traffic.py"),
+                    "serve",
+                    "--config-path",
+                    str(config_path),
+                    "--state-dir",
+                    str(state_dir),
+                    "--port",
+                    str(dashboard_port),
+                    "--interval",
+                    "1",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            try:
+                health = None
+                deadline = time.time() + 6
+                while time.time() < deadline:
+                    try:
+                        with urllib.request.urlopen(
+                            f"http://127.0.0.1:{dashboard_port}/api/health",
+                            timeout=1,
+                        ) as response:
+                            health = json.load(response)
+                        if counter["value"] >= 2:
+                            break
+                    except OSError:
+                        pass
+                    time.sleep(0.15)
+                self.assertIsNotNone(health)
+                self.assertTrue(health["controller_reachable"])
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{dashboard_port}/api/summary?since=24h",
+                    timeout=2,
+                ) as response:
+                    summary = json.load(response)
+                self.assertGreater(summary["total"], 0)
+                stop = subprocess.run(
+                    [
+                        sys.executable,
+                        str(TRAFFIC_DIR / "traffic.py"),
+                        "stop",
+                        "--state-dir",
+                        str(state_dir),
+                    ],
+                    text=True,
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
+                self.assertEqual(stop.returncode, 0, stop.stderr)
+                process.wait(timeout=5)
+                self.assertFalse((state_dir / "traffic.pid").exists())
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=5)
+        controller.shutdown()
+        controller.server_close()
+        controller_thread.join(timeout=2)
+
+
+class InstallLifecycleTests(unittest.TestCase):
+    def test_uninstall_stops_traffic_before_removing_installation(self) -> None:
+        text = (ROOT / "uninstall.sh").read_text(encoding="utf-8")
+        self.assertLess(text.index("traffic_stop"), text.index('rm -rf "$CLASHCTL_HOME"'))
+
+
+class ModelEdgeTests(unittest.TestCase):
+    def test_parse_and_normalize_edge_cases(self) -> None:
+        from model import connection_id, normalize_connection, parse_int
+
+        self.assertEqual(parse_int("12"), 12)
+        self.assertEqual(parse_int(-5), 0)
+        self.assertEqual(parse_int("bad"), 0)
+        self.assertEqual(connection_id({"id": "explicit"}), "explicit")
+        sample = normalize_connection(
+            {
+                "upload": "3",
+                "download": "7",
+                "start": "now",
+                "metadata": {"sourceIP": "10.0.0.8", "sourcePort": 1},
+            }
+        )
+        self.assertTrue(sample.connection_id.startswith("synthetic:"))
+        self.assertEqual(sample.identity.kind, "source-ip")
+        self.assertEqual((sample.upload, sample.download), (3, 7))
+
+    def test_positive_uid_and_unknown_identity(self) -> None:
+        positive = identify_connection({"uid": 999999})
+        self.assertEqual(positive.key, "uid:999999")
+        self.assertEqual(positive.confidence, "medium")
+        self.assertEqual(identify_connection({}).key, "unknown")
+
+
+class StoreRangeTests(unittest.TestCase):
+    def test_time_range_parsing_and_formatting(self) -> None:
+        now = 1_800_000_000
+        self.assertEqual(TrafficStore.since_value("24h", now), now - 86400)
+        self.assertEqual(TrafficStore.since_value("7d", now), now - 604800)
+        self.assertEqual(TrafficStore.since_value("2", now), now - 7200)
+        self.assertEqual(
+            TrafficStore.since_value("2026-08-10T00:00:00Z"),
+            1786320000,
+        )
+        self.assertIsNone(format_utc(None))
+        self.assertTrue(format_utc(0).endswith("Z"))
+        with self.assertRaises(ValueError):
+            TrafficStore.since_value("not-a-range", now)
+
+
+class DashboardRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TrafficStore(Path(self.temp_dir.name) / "traffic.sqlite3")
+        self.server = DashboardServer(
+            ("127.0.0.1", 0), self.store, b"<html>ok</html>", 5.0
+        )
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.server_close()
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def request(self, path: str):
+        result = {}
+
+        def client() -> None:
+            try:
+                result["response"] = urllib.request.urlopen(
+                    self.base_url + path, timeout=2
+                )
+            except Exception as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=client)
+        thread.start()
+        self.server.handle_request()
+        thread.join(timeout=2)
+        return result
+
+    def test_health_range_live_and_not_found_routes(self) -> None:
+        for path in ("/api/health", "/api/range?since=24h", "/api/live"):
+            result = self.request(path)
+            self.assertNotIn("error", result)
+            with result["response"] as response:
+                self.assertEqual(response.status, 200)
+                self.assertIsInstance(json.load(response), dict)
+        result = self.request("/missing")
+        error = result["error"]
+        try:
+            self.assertEqual(error.code, 404)
+        finally:
+            error.close()
+
+    def test_invalid_range_returns_400(self) -> None:
+        result = self.request("/api/range?since=invalid-range")
+        error = result["error"]
+        try:
+            self.assertEqual(error.code, 400)
+        finally:
+            error.close()
+
+
+class CollectorLifecycleUnitTests(unittest.TestCase):
+    def test_stale_pid_is_replaced_and_removed(self) -> None:
+        from collector import acquire_pid_file, is_running, pid_path, read_pid, remove_pid_file
+
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            pid_path(state).write_text("99999999", encoding="ascii")
+            acquire_pid_file(state)
+            self.assertEqual(read_pid(state), __import__("os").getpid())
+            running, pid = is_running(state)
+            self.assertFalse(running)
+            self.assertEqual(pid, __import__("os").getpid())
+            remove_pid_file(state)
+            self.assertIsNone(read_pid(state))
+
+    def test_missing_runtime_config_and_bad_controller(self) -> None:
+        from collector import TrafficError, controller_address, runtime_connection_config
+
+        with self.assertRaises(TrafficError):
+            runtime_connection_config(Path("/definitely/missing/config.yaml"))
+        with self.assertRaises(ValueError):
+            controller_address("127.0.0.1:not-a-port")
+
+
+class DirectCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.state_dir = Path(self.temp_dir.name) / "state"
+        store = TrafficStore(self.state_dir / "traffic.sqlite3")
+        now = int(time.time())
+        identity = Identity("account:alice", "alice", "account", "high")
+        store.record_sample([ConnectionSample("direct", identity, 0, 0)], now)
+        store.record_sample([ConnectionSample("direct", identity, 1024, 2048)], now + 1)
+        store.close()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def namespace(self, **kwargs):
+        import argparse
+
+        return argparse.Namespace(state_dir=str(self.state_dir), **kwargs)
+
+    def capture(self, function, args):
+        import contextlib
+        import io
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            result = function(args)
+        return result, output.getvalue()
+
+    def test_direct_report_live_export_status_stop_and_helpers(self) -> None:
+        result, output = self.capture(
+            traffic_cli.report, self.namespace(since="24h", limit=10)
+        )
+        self.assertEqual(result, 0)
+        self.assertIn("alice", output)
+        result, output = self.capture(traffic_cli.live_report, self.namespace())
+        self.assertEqual(result, 0)
+        self.assertIn("alice", output)
+        result, output = self.capture(
+            traffic_cli.export_csv,
+            self.namespace(since="24h", until=None),
+        )
+        self.assertEqual(result, 0)
+        self.assertIn("total_bytes", output)
+        self.assertIn("user_id", output)
+        self.assertNotIn(",account:alice,", output)
+        result, output = self.capture(traffic_cli.command_status, self.namespace())
+        self.assertEqual(result, 1)
+        self.assertIn("collector=stopped", output)
+        result, output = self.capture(traffic_cli.command_stop, self.namespace())
+        self.assertEqual(result, 0)
+        self.assertIn("collector=stopped", output)
+        self.assertEqual(traffic_cli.bytes_label(1024), "1.0 KB")
+        self.assertEqual(traffic_cli.state_dir_from_arg(str(self.state_dir)), self.state_dir)
+        self.assertIn("serve", traffic_cli.build_parser().format_help())
+
+    def test_main_reports_invalid_range(self) -> None:
+        import contextlib
+        import io
+
+        error = io.StringIO()
+        with contextlib.redirect_stderr(error):
+            result = traffic_cli.main(
+                [
+                    "report",
+                    "--state-dir",
+                    str(self.state_dir),
+                    "--since",
+                    "bad-range",
+                ]
+            )
+        self.assertEqual(result, 1)
+        self.assertIn("无法解析", error.getvalue())
+
+
+class DashboardMarkupTests(unittest.TestCase):
+    def test_chart_empty_overlay_respects_hidden_attribute(self) -> None:
+        html = (TRAFFIC_DIR / "dashboard.html").read_text(encoding="utf-8")
+        self.assertIn(".chart-empty[hidden] { display: none; }", html)
+        self.assertIn("empty.hidden = series.some", html)
+        self.assertIn(".hero-card, .card { min-width: 0;", html)
+        self.assertIn(".table-wrap { min-width: 0; max-width: 100%;", html)
+        self.assertIn("Linux user_id", html)
+        self.assertIn("item.user_id", html)
+
+
+class LinuxSocketUidTests(unittest.TestCase):
+    def test_user_id_is_numeric_linux_uid_only(self) -> None:
+        from store import linux_user_id
+
+        self.assertEqual(linux_user_id("uid:1009", "linux-user"), 1009)
+        self.assertEqual(linux_user_id("uid:0", "linux-user"), 0)
+        self.assertIsNone(linux_user_id("account:alice", "account"))
+        self.assertIsNone(linux_user_id("source-ip:127.0.0.1", "source-ip"))
+        self.assertIsNone(linux_user_id("uid:not-a-number", "linux-user"))
+
+    def proc_line(self, local_port: int, remote_port: int, uid: int) -> str:
+        return (
+            f"0: 0100007F:{local_port:04X} 0100007F:{remote_port:04X} "
+            f"01 00000000:00000000 00:00000000 00000000 {uid} 0 12345 1"
+        )
+
+    def test_proc_socket_snapshot_returns_unique_client_uid(self) -> None:
+        from collector import proc_socket_uid_snapshot
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "tcp").write_text(
+                "sl local_address rem_address st tx_queue tr tm->when retrnsmt uid timeout inode\n"
+                + self.proc_line(58392, 7890, 1009)
+                + "\n",
+                encoding="ascii",
+            )
+            (root / "tcp6").write_text(
+                "sl local_address rem_address st tx_queue tr tm->when retrnsmt uid timeout inode\n"
+                + self.proc_line(7890, 58392, 0)
+                + "\n",
+                encoding="ascii",
+            )
+            snapshot = proc_socket_uid_snapshot(root)
+        self.assertEqual(snapshot[("tcp", 58392)], 1009)
+        self.assertEqual(snapshot[("tcp", 7890)], 0)
+
+    def test_proc_socket_snapshot_rejects_ambiguous_port_ownership(self) -> None:
+        from collector import proc_socket_uid_snapshot
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            header = (
+                "sl local_address rem_address st tx_queue tr tm->when "
+                "retrnsmt uid timeout inode\n"
+            )
+            (root / "tcp").write_text(
+                header
+                + self.proc_line(50000, 7890, 1009)
+                + "\n"
+                + self.proc_line(50000, 7890, 1010)
+                + "\n",
+                encoding="ascii",
+            )
+            snapshot = proc_socket_uid_snapshot(root)
+        self.assertNotIn(("tcp", 50000), snapshot)
+
+    def test_local_socket_uid_uses_loopback_source_only(self) -> None:
+        from collector import local_socket_uid
+
+        snapshot = {("tcp", 58392): 1009}
+        self.assertEqual(
+            local_socket_uid(
+                {"sourceIP": "127.0.0.1", "sourcePort": 58392, "network": "tcp"},
+                snapshot,
+            ),
+            1009,
+        )
+        self.assertIsNone(
+            local_socket_uid(
+                {"sourceIP": "10.0.0.8", "sourcePort": 58392, "network": "tcp"},
+                snapshot,
+            )
+        )
+        self.assertIsNone(
+            local_socket_uid(
+                {"sourceIP": "127.0.0.1", "sourcePort": 0, "network": "tcp"},
+                snapshot,
+            )
+        )
+
+    def test_normalize_connection_prefers_resolved_socket_uid(self) -> None:
+        from model import normalize_connection
+
+        sample = normalize_connection(
+            {
+                "id": "local",
+                "upload": 1,
+                "download": 2,
+                "metadata": {
+                    "uid": 0,
+                    "sourceIP": "127.0.0.1",
+                    "sourcePort": 58392,
+                },
+            },
+            local_uid=1009,
+        )
+        self.assertEqual(sample.identity.key, "uid:1009")
+        self.assertEqual(sample.identity.kind, "linux-user")
+
+    def test_collect_once_takes_one_snapshot_and_attributes_local_uid(self) -> None:
+        from collector import collect_once
+
+        payload = {
+            "connections": [
+                {
+                    "id": "local",
+                    "upload": 10,
+                    "download": 20,
+                    "metadata": {
+                        "uid": 0,
+                        "sourceIP": "127.0.0.1",
+                        "sourcePort": 58392,
+                        "network": "tcp",
+                    },
+                }
+            ]
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            store = TrafficStore(Path(directory) / "traffic.sqlite3")
+            try:
+                with mock.patch("collector.fetch_connections", return_value=payload), mock.patch(
+                    "collector.proc_socket_uid_snapshot",
+                    return_value={("tcp", 58392): 1009},
+                ) as snapshot:
+                    collect_once(store, "127.0.0.1:9090", "")
+                snapshot.assert_called_once_with()
+                row = store.connection.execute(
+                    "SELECT identity_key, identity_kind FROM connection_state"
+                ).fetchone()
+                self.assertEqual(tuple(row), ("uid:1009", "linux-user"))
+                live = store.live()[0]
+                self.assertEqual(live["user_id"], 1009)
+                self.assertIsInstance(live["user_id"], int)
+            finally:
+                store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import socket
+import stat
 import subprocess  # nosec B404  # nosemgrep
 import sys
 import tempfile
@@ -214,6 +215,12 @@ class StoreTests(unittest.TestCase):
         result = self.store.record_sample([self.sample(10, 20)], 1_700_000_005)
         self.assertEqual(result["upload"], 10)
         self.assertEqual(result["download"], 20)
+
+    def test_store_uses_owner_only_filesystem_permissions(self) -> None:
+        directory_mode = stat.S_IMODE(self.store.path.parent.stat().st_mode)
+        database_mode = stat.S_IMODE(self.store.path.stat().st_mode)
+        self.assertEqual(directory_mode, stat.S_IRWXU)
+        self.assertEqual(database_mode, stat.S_IRUSR | stat.S_IWUSR)
 
     def test_database_does_not_store_destination_or_process_fields(self) -> None:
         schema_queries = (

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -287,6 +287,18 @@ class DashboardServerTests(unittest.TestCase):
         self.assertEqual(payload["users"][0]["display_name"], "alice")
         self.assertIsNone(payload["users"][0]["user_id"])
 
+    def test_client_disconnect_does_not_trigger_error_response(self) -> None:
+        handler = mock.Mock()
+        handler.send_response = mock.Mock()
+        handler.send_header = mock.Mock()
+        handler.end_headers = mock.Mock(side_effect=BrokenPipeError)
+        handler.wfile = mock.Mock()
+
+        from server import DashboardHandler
+
+        DashboardHandler._send(handler, 200, "application/json", b"{}")
+        handler.wfile.write.assert_not_called()
+
     def test_security_header_is_not_duplicated(self) -> None:
         with self.request("/") as response:
             values = response.headers.get_all("X-Content-Type-Options")
@@ -392,6 +404,42 @@ class CollectorTests(unittest.TestCase):
         ):
             with self.subTest(value=value), self.assertRaises(ValueError):
                 controller_address(value)
+
+    def test_collect_once_treats_null_connections_as_empty_sample(self) -> None:
+        from collector import collect_once
+
+        payload = {"connections": None, "uploadTotal": 12, "downloadTotal": 34}
+        with tempfile.TemporaryDirectory() as directory:
+            store = TrafficStore(Path(directory) / "traffic.sqlite3")
+            try:
+                with mock.patch("collector.fetch_connections", return_value=payload), mock.patch(
+                    "collector.proc_socket_uid_snapshot"
+                ) as snapshot:
+                    result = collect_once(store, "127.0.0.1:9090", "")
+                snapshot.assert_called_once_with()
+                self.assertEqual(
+                    result,
+                    {"connections": 0, "identities": 0, "upload": 0, "download": 0},
+                )
+                self.assertEqual(store.get_meta("controller_reachable"), "1")
+                self.assertEqual(store.get_meta("global_upload_total"), "12")
+                self.assertEqual(store.get_meta("global_download_total"), "34")
+            finally:
+                store.close()
+
+    def test_collect_once_rejects_non_list_non_null_connections(self) -> None:
+        from collector import TrafficError, collect_once
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = TrafficStore(Path(directory) / "traffic.sqlite3")
+            try:
+                with mock.patch(
+                    "collector.fetch_connections", return_value={"connections": {}}
+                ), self.assertRaises(TrafficError):
+                    collect_once(store, "127.0.0.1:9090", "")
+                self.assertEqual(store.get_meta("controller_reachable"), "0")
+            finally:
+                store.close()
 
     def test_collect_once_reads_mihomo_payload_and_never_persists_destination(self) -> None:
         from collector import collect_once

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import socket
-import subprocess
+import subprocess  # nosec B404  # nosemgrep
 import sys
 import tempfile
 import threading
@@ -20,6 +20,150 @@ from model import ConnectionSample, Identity, identify_connection  # noqa: E402
 from server import DashboardServer  # noqa: E402
 from store import TrafficStore, format_utc  # noqa: E402
 import traffic as traffic_cli  # noqa: E402
+
+
+def start_json_server(payloads: list[dict]):
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format, *_args):
+            return
+
+        def do_GET(self):  # noqa: N802
+            body = json.dumps(payloads.pop(0)).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def stop_http_server(server, thread) -> None:
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=2)
+
+
+def traffic_payload(upload: int, download: int) -> dict:
+    return {
+        "uploadTotal": upload,
+        "downloadTotal": download,
+        "connections": [
+            {
+                "id": "connection-1",
+                "upload": upload,
+                "download": download,
+                "metadata": {
+                    "inboundUser": "alice",
+                    "host": "private.example",
+                    "processPath": "/sensitive/process",
+                },
+            }
+        ],
+    }
+
+
+def start_incrementing_controller(counter: dict[str, int]):
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, _format, *_args):
+            return
+
+        def do_GET(self):  # noqa: N802
+            counter["value"] += 1
+            value = counter["value"] * 1024
+            body = json.dumps(
+                {
+                    "uploadTotal": value,
+                    "downloadTotal": value * 2,
+                    "connections": [
+                        {
+                            "id": "live-connection",
+                            "upload": value,
+                            "download": value * 2,
+                            "metadata": {"inboundUser": "alice"},
+                        }
+                    ],
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def available_loopback_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def start_traffic_process(config_path: Path, state_dir: Path, port: int):
+    return subprocess.Popen(  # nosec B603  # nosemgrep
+        [
+            sys.executable,
+            str(TRAFFIC_DIR / "traffic.py"),
+            "serve",
+            "--config-path",
+            str(config_path),
+            "--state-dir",
+            str(state_dir),
+            "--port",
+            str(port),
+            "--interval",
+            "1",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+
+def load_loopback_json(port: int, path: str, timeout: float = 2) -> dict:
+    url = f"http://127.0.0.1:{port}{path}"
+    with urllib.request.urlopen(url, timeout=timeout) as response:  # nosec B310
+        return json.load(response)
+
+
+def wait_for_collector_health(port: int, counter: dict[str, int]) -> dict | None:
+    deadline = time.time() + 6
+    while time.time() < deadline:
+        try:
+            health = load_loopback_json(port, "/api/health", timeout=1)
+            if counter["value"] >= 2:
+                return health
+        except OSError:
+            pass
+        time.sleep(0.15)
+    return None
+
+
+def stop_traffic_process(state_dir: Path):
+    return subprocess.run(  # nosec B603  # nosemgrep
+        [
+            sys.executable,
+            str(TRAFFIC_DIR / "traffic.py"),
+            "stop",
+            "--state-dir",
+            str(state_dir),
+        ],
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
 
 
 class IdentityTests(unittest.TestCase):
@@ -72,10 +216,15 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(result["download"], 20)
 
     def test_database_does_not_store_destination_or_process_fields(self) -> None:
+        schema_queries = (
+            "PRAGMA table_info(traffic_minute)",
+            "PRAGMA table_info(connection_state)",
+            "PRAGMA table_info(live_identity)",
+        )
         columns = {
             row[1]
-            for table in ("traffic_minute", "connection_state", "live_identity")
-            for row in self.store.connection.execute(f"PRAGMA table_info({table})")
+            for query in schema_queries
+            for row in self.store.connection.execute(query)
         }
         forbidden = {"host", "destination", "process", "process_path", "source_port"}
         self.assertTrue(columns.isdisjoint(forbidden))
@@ -109,7 +258,7 @@ class DashboardServerTests(unittest.TestCase):
 
         def client() -> None:
             try:
-                result["response"] = urllib.request.urlopen(
+                result["response"] = urllib.request.urlopen(  # nosec B310  # nosemgrep
                     self.base_url + path, timeout=2
                 )
             except Exception as exc:  # re-raised in the test thread
@@ -221,89 +370,59 @@ class CollectorTests(unittest.TestCase):
 
         self.assertEqual(controller_address("0.0.0.0:9090"), "127.0.0.1:9090")
         self.assertEqual(controller_address("[::]:9091"), "127.0.0.1:9091")
+        self.assertEqual(controller_address("[::1]:9092"), "[::1]:9092")
+
+    def test_controller_address_rejects_url_syntax_and_invalid_ports(self) -> None:
+        from collector import controller_address
+
+        for value in (
+            "http://example.com:9090",
+            "file:///tmp/controller",
+            "user@example.com:9090",
+            "127.0.0.1:9090/connections",
+            "127.0.0.1:0",
+            "127.0.0.1:65536",
+        ):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                controller_address(value)
 
     def test_collect_once_reads_mihomo_payload_and_never_persists_destination(self) -> None:
-        from http.server import BaseHTTPRequestHandler, HTTPServer
         from collector import collect_once
 
-        payloads = [
-            {
-                "uploadTotal": 100,
-                "downloadTotal": 200,
-                "connections": [
-                    {
-                        "id": "connection-1",
-                        "upload": 10,
-                        "download": 20,
-                        "metadata": {
-                            "inboundUser": "alice",
-                            "host": "private.example",
-                            "processPath": "/sensitive/process",
-                        },
-                    }
-                ],
-            },
-            {
-                "uploadTotal": 150,
-                "downloadTotal": 280,
-                "connections": [
-                    {
-                        "id": "connection-1",
-                        "upload": 30,
-                        "download": 70,
-                        "metadata": {
-                            "inboundUser": "alice",
-                            "host": "private.example",
-                            "processPath": "/sensitive/process",
-                        },
-                    }
-                ],
-            },
-        ]
-
-        class Handler(BaseHTTPRequestHandler):
-            def log_message(self, _format, *_args):
-                return
-
-            def do_GET(self):  # noqa: N802
-                body = json.dumps(payloads.pop(0)).encode()
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-
-        server = HTTPServer(("127.0.0.1", 0), Handler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
+        payloads = [traffic_payload(10, 20), traffic_payload(30, 70)]
+        payloads[0].update(uploadTotal=100, downloadTotal=200)
+        payloads[1].update(uploadTotal=150, downloadTotal=280)
+        server, thread = start_json_server(payloads)
         try:
             with tempfile.TemporaryDirectory() as directory:
                 store = TrafficStore(Path(directory) / "traffic.sqlite3")
-                address = f"127.0.0.1:{server.server_port}"
-                collect_once(store, address, "")
-                result = collect_once(store, address, "")
-                self.assertEqual(result["upload"], 20)
-                self.assertEqual(result["download"], 50)
-                dump = "\n".join(
-                    row[0]
-                    for row in store.connection.execute(
-                        "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"
+                try:
+                    address = f"127.0.0.1:{server.server_port}"
+                    collect_once(store, address, "")
+                    result = collect_once(store, address, "")
+                    self.assertEqual((result["upload"], result["download"]), (20, 50))
+                    schema = "\n".join(
+                        row[0]
+                        for row in store.connection.execute(
+                            "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL"
+                        )
                     )
-                )
-                rows = repr(store.connection.execute("SELECT * FROM connection_state").fetchall())
-                self.assertNotIn("private.example", dump + rows)
-                self.assertNotIn("/sensitive/process", dump + rows)
-                store.close()
+                    rows = repr(
+                        store.connection.execute(
+                            "SELECT * FROM connection_state"
+                        ).fetchall()
+                    )
+                    self.assertNotIn("private.example", schema + rows)
+                    self.assertNotIn("/sensitive/process", schema + rows)
+                finally:
+                    store.close()
         finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=2)
+            stop_http_server(server, thread)
+
 
 
 class CliTests(unittest.TestCase):
     def setUp(self) -> None:
-        import subprocess
-
         self.subprocess = subprocess
         self.temp_dir = tempfile.TemporaryDirectory()
         self.state_dir = Path(self.temp_dir.name) / "state"
@@ -318,7 +437,7 @@ class CliTests(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def run_cli(self, *args: str):
-        return self.subprocess.run(
+        return self.subprocess.run(  # nosec B603  # nosemgrep
             [sys.executable, str(TRAFFIC_DIR / "traffic.py"), *args],
             text=True,
             capture_output=True,
@@ -389,7 +508,7 @@ class ProcessLifecycleTests(unittest.TestCase):
             blocker.listen(1)
             port = blocker.getsockname()[1]
             try:
-                result = subprocess.run(
+                result = subprocess.run(  # nosec B603  # nosemgrep
                     [
                         sys.executable,
                         str(TRAFFIC_DIR / "traffic.py"),
@@ -412,119 +531,39 @@ class ProcessLifecycleTests(unittest.TestCase):
             self.assertFalse((state_dir / "traffic.pid").exists())
 
     def test_real_process_health_sampling_and_stop(self) -> None:
-        from http.server import BaseHTTPRequestHandler, HTTPServer
-
         counter = {"value": 0}
-
-        class Handler(BaseHTTPRequestHandler):
-            def log_message(self, _format, *_args):
-                return
-
-            def do_GET(self):  # noqa: N802
-                counter["value"] += 1
-                value = counter["value"] * 1024
-                body = json.dumps(
-                    {
-                        "uploadTotal": value,
-                        "downloadTotal": value * 2,
-                        "connections": [
-                            {
-                                "id": "live-connection",
-                                "upload": value,
-                                "download": value * 2,
-                                "metadata": {"inboundUser": "alice"},
-                            }
-                        ],
-                    }
-                ).encode()
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-
-        controller = HTTPServer(("127.0.0.1", 0), Handler)
-        controller_thread = threading.Thread(
-            target=controller.serve_forever, daemon=True
-        )
-        controller_thread.start()
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            state_dir = root / "state"
-            config_path = root / "runtime.yaml"
-            config_path.write_text(
-                f"external-controller: 127.0.0.1:{controller.server_port}\n"
-                "secret: ''\n",
-                encoding="utf-8",
-            )
-            dashboard_socket = socket.socket()
-            dashboard_socket.bind(("127.0.0.1", 0))
-            dashboard_port = dashboard_socket.getsockname()[1]
-            dashboard_socket.close()
-            process = subprocess.Popen(
-                [
-                    sys.executable,
-                    str(TRAFFIC_DIR / "traffic.py"),
-                    "serve",
-                    "--config-path",
-                    str(config_path),
-                    "--state-dir",
-                    str(state_dir),
-                    "--port",
-                    str(dashboard_port),
-                    "--interval",
-                    "1",
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                text=True,
-            )
-            try:
-                health = None
-                deadline = time.time() + 6
-                while time.time() < deadline:
-                    try:
-                        with urllib.request.urlopen(
-                            f"http://127.0.0.1:{dashboard_port}/api/health",
-                            timeout=1,
-                        ) as response:
-                            health = json.load(response)
-                        if counter["value"] >= 2:
-                            break
-                    except OSError:
-                        pass
-                    time.sleep(0.15)
-                self.assertIsNotNone(health)
-                self.assertTrue(health["controller_reachable"])
-                with urllib.request.urlopen(
-                    f"http://127.0.0.1:{dashboard_port}/api/summary?since=24h",
-                    timeout=2,
-                ) as response:
-                    summary = json.load(response)
-                self.assertGreater(summary["total"], 0)
-                stop = subprocess.run(
-                    [
-                        sys.executable,
-                        str(TRAFFIC_DIR / "traffic.py"),
-                        "stop",
-                        "--state-dir",
-                        str(state_dir),
-                    ],
-                    text=True,
-                    capture_output=True,
-                    timeout=5,
-                    check=False,
+        controller, controller_thread = start_incrementing_controller(counter)
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                state_dir = root / "state"
+                config_path = root / "runtime.yaml"
+                config_path.write_text(
+                    f"external-controller: 127.0.0.1:{controller.server_port}\n"
+                    "secret: ''\n",
+                    encoding="utf-8",
                 )
-                self.assertEqual(stop.returncode, 0, stop.stderr)
-                process.wait(timeout=5)
-                self.assertFalse((state_dir / "traffic.pid").exists())
-            finally:
-                if process.poll() is None:
-                    process.terminate()
+                dashboard_port = available_loopback_port()
+                process = start_traffic_process(config_path, state_dir, dashboard_port)
+                try:
+                    health = wait_for_collector_health(dashboard_port, counter)
+                    self.assertIsNotNone(health)
+                    self.assertTrue(health["controller_reachable"])
+                    summary = load_loopback_json(
+                        dashboard_port, "/api/summary?since=24h"
+                    )
+                    self.assertGreater(summary["total"], 0)
+                    stop = stop_traffic_process(state_dir)
+                    self.assertEqual(stop.returncode, 0, stop.stderr)
                     process.wait(timeout=5)
-        controller.shutdown()
-        controller.server_close()
-        controller_thread.join(timeout=2)
+                    self.assertFalse((state_dir / "traffic.pid").exists())
+                finally:
+                    if process.poll() is None:
+                        process.terminate()
+                        process.wait(timeout=5)
+        finally:
+            stop_http_server(controller, controller_thread)
+
 
 
 class InstallLifecycleTests(unittest.TestCase):
@@ -595,7 +634,7 @@ class DashboardRouteTests(unittest.TestCase):
 
         def client() -> None:
             try:
-                result["response"] = urllib.request.urlopen(
+                result["response"] = urllib.request.urlopen(  # nosec B310  # nosemgrep
                     self.base_url + path, timeout=2
                 )
             except Exception as exc:

--- a/tests/test_traffic_shell.sh
+++ b/tests/test_traffic_shell.sh
@@ -8,6 +8,20 @@ _okcat() { printf '%s\n' "$*"; return 0; }
 . "$REPO/scripts/cmd/traffic.sh"
 
 fail=0
+original_override=${CLASHCTL_TRAFFIC_PYTHON-}
+CLASHCTL_TRAFFIC_PYTHON=$(command -v bash)
+if [ "$(traffic_python)" != "$CLASHCTL_TRAFFIC_PYTHON" ]; then
+  printf '%s\n' 'FAIL: traffic_python did not honor CLASHCTL_TRAFFIC_PYTHON' >&2
+  fail=1
+fi
+CLASHCTL_TRAFFIC_PYTHON=/definitely/missing/python
+if traffic_python >/dev/null 2>&1; then
+  printf '%s\n' 'FAIL: traffic_python accepted a missing override' >&2
+  fail=1
+fi
+CLASHCTL_TRAFFIC_PYTHON=$original_override
+unset original_override
+
 expect_invalid() {
   local expected=$1
   shift

--- a/tests/test_traffic_shell.sh
+++ b/tests/test_traffic_shell.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -u
+REPO=$(cd -- "$(dirname -- "$0")/.." && pwd -P)
+export CLASHCTL_HOME=$REPO
+export CLASH_CONFIG_RUNTIME=$REPO/resources/runtime.yaml
+_errorcat() { printf '%s\n' "$*" >&2; return 1; }
+_okcat() { printf '%s\n' "$*"; return 0; }
+. "$REPO/scripts/cmd/traffic.sh"
+
+fail=0
+expect_invalid() {
+  local expected=$1
+  shift
+  local output rc
+  output=$(traffic_start "$@" 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ] || ! grep -Fq "$expected" <<<"$output"; then
+    printf 'FAIL: traffic_start %s\noutput: %s\n' "$*" "$output" >&2
+    fail=1
+  fi
+}
+
+expect_invalid '端口必须是 1024-65535' --port nope
+expect_invalid '端口必须是 1024-65535' --port 70000
+expect_invalid '采样间隔必须是大于等于 1 的数字' --interval 0
+expect_invalid '采样间隔必须是大于等于 1 的数字' --interval nope
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+printf '%s\n' 'shell validation tests passed'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,11 +3,13 @@
 CLASHCTL_SRC="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 . "$CLASHCTL_SRC/scripts/preflight.sh"
 . "$CLASHCTL_SRC/scripts/cmd/off.sh"
+. "$CLASHCTL_SRC/scripts/cmd/traffic.sh"
 
 ! _is_root && tunstatus >&/dev/null && {
     _errorcat "请先关闭 Tun 模式"
     exit
 }
+traffic_stop >/dev/null 2>&1 || true
 uninstall_service
 
 command -v crontab >&/dev/null && {


### PR DESCRIPTION
## Background

`clashctl` can manage the Mihomo service, subscriptions, and dashboards, but it cannot currently answer which local Linux users are consuming proxy traffic or how much traffic each user consumes.

This change adds persistent traffic accounting by Linux UID, CLI reporting and export, and a Web dashboard. It combines per-connection byte counters from Mihomo's `/connections` endpoint with Linux socket ownership information from `/proc/net/*`.

## Changes

- Add a Python standard-library-only collector backed by SQLite:
  - sample connection byte counters every 5 seconds by default;
  - establish a baseline on the first observation and count only subsequent deltas;
  - handle counter resets, stale connection cleanup, and sampling gaps.

- Add Linux UID attribution for local proxy clients:
  - read `/proc/net/{tcp,tcp6,udp,udp6}` once per successful sample;
  - match Mihomo's loopback `sourcePort` to the client socket's local port;
  - use the UID only when port ownership is unambiguous;
  - fall back for ambiguous, remote, or unresolved connections;
  - never persist ports, inodes, process paths, or raw connection destinations.

- Define separate identity fields:
  - `user_id`: a numeric Linux UID, or `null` when the connection cannot be mapped to a local Linux user;
  - `identity_key`: a generic attribution key such as `uid:<UID>`, `account:<user>`, `source-ip:<IP>`, or `unknown`.

- Add `clashctl traffic` commands:
  - `start`, `stop`, `status`, and `ui`;
  - `today`, `top`, and `live`;
  - CSV export with `export --since ...`.

- Add a loopback-only Web dashboard:
  - total traffic, download/upload ratio, active and tracked identities, and sample count;
  - separate download and upload curves with visible sampling gaps;
  - active connections and an identity traffic ledger;
  - explicit Linux `user_id` and generic `identity_key` display;
  - responsive desktop/mobile layouts and security response headers.

- Integrate collector lifecycle with installation and removal:
  - install `scripts/traffic` with the rest of clashctl;
  - validate Python 3.10+, the dashboard port, and the sampling interval before startup;
  - verify startup through a protected PID file and `/api/health`;
  - stop the collector precisely before uninstalling clashctl.

- Update the README with commands, identity semantics, permissions, SSH tunneling, privacy boundaries, and sampling limitations.

## Privacy and security

- The product dashboard listens on loopback by default.
- Wildcard Mihomo controller addresses are coerced to loopback for collector access.
- The browser never receives the Mihomo controller secret or raw connection destinations.
- SQLite stores only identity information, attribution type, confidence, and byte deltas. It does not store destination domains or IPs, process paths, ports, inodes, traffic contents, or raw controller responses.
- The state directory, database, and PID file use permissions `700`, `600`, and `600`, respectively.

## Accuracy limitations

This feature provides sampled telemetry, not billing-grade accounting:

- the first observation establishes a baseline only;
- short-lived connections that complete between samples may be missed;
- traffic transferred after the final successful sample and before a connection disappears cannot be recovered;
- traffic during collector downtime or controller failures is not backfilled;
- non-loopback or ambiguously owned connections fall back to an authenticated account, a positive UID reported by Mihomo, a source IP, or `unknown`.

## Verification

- `PYTHONWARNINGS=error::ResourceWarning python3 -m unittest -q tests/test_traffic.py`
- `bash tests/test_traffic_shell.sh`
- `python3 -m py_compile scripts/traffic/*.py`
- `bash -n scripts/cmd/traffic.sh scripts/preflight.sh uninstall.sh`
- `git diff --check`
- 37 Python tests pass.
- Branch coverage: **83.05%** across 627 statements and 134 branches.
- Sensitive-information scan across 14 changed files: **0 findings**.
- Playwright desktop and mobile verification reports no console errors or page-level horizontal overflow.
- Live verification attributes the Hugging Face download traffic to Linux UID `1009`; the API exposes numeric `user_id: 1009` and `identity_key: "uid:1009"`.
