### PR TITLE
docs: 恢复已损坏的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ bash uninstall.sh
 - 🔑 自营号池保障可用性，日常调用更稳定。
 - 🎁 新用户注册赠送 `$2` 额度：👉[立即注册](https://api.muteki.site/register?aff=NELVKO&promo=nelvko)
 
+## ⭐ Star History
+
+<a href="https://star-history.dera.page/#nelvko/clash-for-linux-install&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=nelvko/clash-for-linux-install&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=nelvko/clash-for-linux-install&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=nelvko/clash-for-linux-install&type=Date" />
+ </picture>
+</a>
+
 ## ⚠️ Disclaimer
 
 - 编写本项目主要目的为学习和研究 `Shell` 编程，不得将本项目中任何内容用于违反国家/地区/组织等的法律法规或相关规定的其他用途。


### PR DESCRIPTION
当前 README 中的 Star History 图表是空的，因为上游 star-history.com 的图表依赖已受限的 GitHub Stargazer API，实际上无法加载。

本 PR 恢复之前版本中已存在的 Star History 图表，并切换到新的 star-history.dera.page 数据源。该数据源无需 API Token 即可工作，让图表重新恢复可用。

相关提交：ebb184b 移除了该图表。