### PR TITLE
fix(sub): 修复交互粘贴与方向键输入

### DIFF
--- a/scripts/cmd/sub.sh
+++ b/scripts/cmd/sub.sh
@@ -442,6 +442,19 @@ _sub_pick() {
 #            子命令
 ########################################
 
+# 为交互输入启用当前 Shell 自带的行编辑器；非 TTY/非交互场景保持普通 read。
+_sub_read_input() {
+    local target=$1
+
+    if [ -n "${ZSH_VERSION:-}" ] && [[ $- == *i* ]] && [ -t 0 ] && [ -t 1 ]; then
+        vared "$target"
+    elif [ -n "${BASH_VERSION:-}" ] && [ -t 0 ] && [ -t 1 ]; then
+        IFS= read -e -r "${target?}"
+    else
+        IFS= read -r "${target?}"
+    fi
+}
+
 sub_add() {
     local use_after_add=false name='' url='' strategy=auto
 
@@ -542,7 +555,10 @@ EOF
     [ -z "$url" ] && [ $# -gt 0 ] && url=$1
     [ -z "$url" ] && {
         printf '%s' "$(_okcat '✈️ ' '请输入要添加的订阅链接：')"
-        read -r url
+        _sub_read_input url
+        # 非行编辑回退路径也不能把 bracketed-paste 边界当成 URL 内容。
+        url=${url#$'\033[200~'}
+        url=${url%$'\033[201~'}
         [ -z "$url" ] && {
             _errorcat "订阅链接不能为空"
             return 1

--- a/tests/test_sub_interactive_input.sh
+++ b/tests/test_sub_interactive_input.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+SUB_SCRIPT="${REPO_ROOT}/scripts/cmd/sub.sh"
+errors=0
+
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; errors=$((errors + 1)); }
+
+if ! command -v script >/dev/null 2>&1; then
+    echo 'SKIP: script is unavailable'
+    exit 0
+fi
+
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+cat >"$test_root/probe.sh" <<'EOF'
+source "$1"
+
+_okcat() { printf '%s' "$*"; }
+_errorcat() { printf 'ERROR: %s\n' "$*" >&2; }
+_sub_url_exists() { return 1; }
+_sub_download() {
+    _SUB_DL_FILE=/dev/null
+    FETCH_USERINFO=''
+    FETCH_FILENAME=''
+    return 0
+}
+_with_profiles_lock() {
+    [ "$1" = _sub_add_locked ] || return 90
+    printf 'RESULT=%s\n' "$3"
+}
+
+sub_add
+EOF
+
+run_case() {
+    local shell=$1 name=$2 input=$3 expected=$4 output actual shell_command
+    output="$test_root/${shell}-${name}.out"
+
+    case "$shell" in
+    bash) shell_command="'$shell' --noprofile --norc -i" ;;
+    zsh) shell_command="'$shell' -f -i" ;;
+    esac
+
+    printf '%b' "$input" | TERM=xterm-256color script -qfec \
+        "stty cols 120 rows 30; TERM=xterm-256color $shell_command '$test_root/probe.sh' '$SUB_SCRIPT'" \
+        /dev/null >"$output" 2>&1
+
+    actual="$(tr -d '\r' <"$output" | sed -n 's/.*RESULT=//p' | tail -1)"
+    if [ "$actual" = "$expected" ]; then
+        pass "$shell $name"
+    else
+        fail "$shell $name (expected '$expected', got '$actual')"
+        tr -d '\r' <"$output" | tail -5
+    fi
+}
+
+run_fallback_case() {
+    local shell=$1 output actual
+    output="$test_root/${shell}-fallback.out"
+
+    printf '%b' '\033[200~https://example.invalid/fallback\033[201~\n' |
+        "$shell" "$test_root/probe.sh" "$SUB_SCRIPT" >"$output" 2>&1
+    actual="$(tr -d '\r' <"$output" | sed -n 's/.*RESULT=//p' | tail -1)"
+    if [ "$actual" = 'https://example.invalid/fallback' ]; then
+        pass "$shell non-TTY fallback"
+    else
+        fail "$shell non-TTY fallback (got '$actual')"
+    fi
+}
+
+for shell in bash zsh; do
+    command -v "$shell" >/dev/null 2>&1 || continue
+    run_case "$shell" bracketed-paste \
+        '\033[200~https://example.invalid/sub?id=1\033[201~\n' \
+        'https://example.invalid/sub?id=1'
+    run_case "$shell" left-arrow 'ab\033[DZ\n' 'aZb'
+    run_fallback_case "$shell"
+done
+
+if [ "$errors" -eq 0 ]; then
+    echo 'PASS: interactive subscription input'
+    exit 0
+fi
+
+echo "FAIL: interactive subscription input ($errors error(s))"
+exit 1


### PR DESCRIPTION
## 问题

`clashctl sub add` 省略 URL 时直接使用 `read -r url`。终端处于 bracketed-paste 模式时，粘贴边界会进入 URL；方向键的转义序列也会被当作普通字符。

## 修复

- Bash TTY 输入使用 Readline (`read -e -r`)
- 交互 Zsh 输入使用 ZLE (`vared`)
- 非 TTY/回退路径保留普通 `read -r`
- 防御性移除 URL 首尾的 bracketed-paste 边界
- 不覆盖全局 `read`，不增加外部依赖，只影响 `sub add` 的交互 URL 输入

## 验证

- Bash：bracketed paste、左方向键、非 TTY 回退
- Zsh：bracketed paste、左方向键、非 TTY 回退
- Ubuntu 26.04 NAS 真机通过
- `bash -n`、`zsh -n`、ShellCheck 通过

Fixes #617
