### PR TITLE
fix(shell): 在 Zsh 中通过 Bash 执行 clashctl

### DIFF
--- a/scripts/cmd/clashctl.fish
+++ b/scripts/cmd/clashctl.fish
@@ -19,6 +19,11 @@ end
 
 function clashon --description 'start clash service and/or enable proxy env'
     set -l capture 1
+    if not set -q argv[1]
+        if set -q CLASHCTL_MANAGE_SHELL_PROXY; and test "$CLASHCTL_MANAGE_SHELL_PROXY" = 0
+            set capture 0
+        end
+    end
     if set -q argv[1]
         switch $argv[1]
             case -s --service-only -h --help
@@ -49,6 +54,11 @@ end
 
 function clashoff --description 'stop clash service and/or disable proxy env'
     set -l drop_env 1
+    if not set -q argv[1]
+        if set -q CLASHCTL_MANAGE_SHELL_PROXY; and test "$CLASHCTL_MANAGE_SHELL_PROXY" = 0
+            set drop_env 0
+        end
+    end
     if set -q argv[1]
         switch $argv[1]
             case -s --service-only -h --help

--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [ -n "${ZSH_VERSION:-}" ] && [ -z "${BASH_VERSION:-}" ]; then
+    # shellcheck source=/dev/null
+    . "$CLASHCTL_HOME/scripts/cmd/clashctl.zsh"
+    return
+fi
+
 . "$CLASHCTL_HOME"/.env
 
 for lib_file in "$CLASHCTL_HOME"/scripts/lib/*.sh; do

--- a/scripts/cmd/clashctl.zsh
+++ b/scripts/cmd/clashctl.zsh
@@ -1,0 +1,80 @@
+# Zsh adapter: keep the implementation in Bash and bridge only parent-shell state.
+
+__clashctl_run() {
+    local fn=$1
+    shift
+    command bash -c '. "$CLASHCTL_HOME/scripts/cmd/clashctl.sh" && "$1" "${@:2}"' \
+        -- "$fn" "$@"
+}
+
+clashon() {
+    if [ "${CLASHCTL_MANAGE_SHELL_PROXY:-1}" = 0 ] && [ "$#" -eq 0 ]; then
+        __clashctl_run on_service_only
+        return
+    fi
+
+    case "${1:-}" in
+    -s | --service-only | -h | --help)
+        __clashctl_run clashon "$@"
+        return
+        ;;
+    esac
+
+    local env_code
+    env_code=$(command bash -c \
+        '. "$CLASHCTL_HOME/scripts/cmd/clashctl.sh" && clashon "$@" 1>&2 && _dump_proxy_env_zsh' \
+        -- "$@")
+    local rc=$?
+    [ "$rc" -eq 0 ] || return "$rc"
+    eval "$env_code"
+}
+
+clashoff() {
+    if [ "${CLASHCTL_MANAGE_SHELL_PROXY:-1}" = 0 ] && [ "$#" -eq 0 ]; then
+        __clashctl_run off_service_only
+        return
+    fi
+
+    local drop_env=true
+    case "${1:-}" in
+    -s | --service-only | -h | --help) drop_env=false ;;
+    esac
+
+    __clashctl_run clashoff "$@"
+    local rc=$?
+
+    if [ "$drop_env" = true ]; then
+        unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY \
+            all_proxy ALL_PROXY no_proxy NO_PROXY
+    fi
+    return "$rc"
+}
+
+local cmd_file base fn
+for cmd_file in "$CLASHCTL_HOME"/scripts/cmd/*.sh(N); do
+    base=${cmd_file:t:r}
+    case "$base" in
+    clashctl | on | off) continue ;;
+    esac
+    fn="clash${base}"
+    (( $+functions[$fn] )) && continue
+    eval "${fn}() { __clashctl_run ${fn} \"\$@\"; }"
+done
+unset cmd_file base fn
+
+clashctl() {
+    local sub_cmd=${1:-help}
+    [ "$#" -eq 0 ] || shift
+
+    case "$sub_cmd" in
+    -h | --help | help) sub_cmd=help ;;
+    esac
+
+    local target="clash${sub_cmd}"
+    (( $+functions[$target] )) || {
+        print -u2 -- "Unknown subcommand: $target"
+        print -u2 -- "Use 'clashctl help' for usage information."
+        return 1
+    }
+    "$target" "$@"
+}

--- a/scripts/cmd/off.sh
+++ b/scripts/cmd/off.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 clashoff() {
-    case "$1" in
+    if [ "${CLASHCTL_MANAGE_SHELL_PROXY:-1}" = 0 ] && [ "$#" -eq 0 ]; then
+        off_service_only
+        return
+    fi
+
+    case "${1:-}" in
     -e | --env-only)
         off_env_only
         ;;

--- a/scripts/cmd/on.sh
+++ b/scripts/cmd/on.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 clashon() {
-    case "$1" in
+    if [ "${CLASHCTL_MANAGE_SHELL_PROXY:-1}" = 0 ] && [ "$#" -eq 0 ]; then
+        on_service_only
+        return
+    fi
+
+    case "${1:-}" in
     -e | --env-only)
         on_env_only
         ;;
@@ -90,5 +95,14 @@ _dump_proxy_env_fish() {
         val=${val//\\/\\\\}
         val=${val//\'/\\\'}
         printf "set -gx %s '%s'\n" "$v" "$val"
+    done
+}
+
+_dump_proxy_env_zsh() {
+    local v val
+    for v in http_proxy HTTP_PROXY https_proxy HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY; do
+        val=${!v}
+        [ -z "$val" ] && continue
+        printf 'export %s=%q\n' "$v" "$val"
     done
 }

--- a/tests/test_zsh_bash_adapter.sh
+++ b/tests/test_zsh_bash_adapter.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+
+command -v zsh >/dev/null 2>&1 || {
+    echo 'SKIP: zsh is unavailable'
+    exit 0
+}
+
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+mkdir -p "$test_root/bin" "$test_root/resources" "$test_root/scripts/cmd" "$test_root/scripts/lib"
+ln -s "$REPO_ROOT/scripts/cmd/clashctl.sh" "$test_root/scripts/cmd/clashctl.sh"
+[ ! -f "$REPO_ROOT/scripts/cmd/clashctl.zsh" ] ||
+    ln -s "$REPO_ROOT/scripts/cmd/clashctl.zsh" "$test_root/scripts/cmd/clashctl.zsh"
+ln -s "$REPO_ROOT/scripts/cmd/on.sh" "$test_root/scripts/cmd/on.sh"
+ln -s "$REPO_ROOT/scripts/cmd/off.sh" "$test_root/scripts/cmd/off.sh"
+
+cat >"$test_root/.env" <<'EOF'
+CLASHCTL_KERNEL=mihomo
+EOF
+
+cat >"$test_root/bin/yq" <<'EOF'
+#!/bin/sh
+printf '7897|||\n'
+EOF
+chmod +x "$test_root/bin/yq"
+
+cat >"$test_root/scripts/lib/common.sh" <<'EOF'
+BIN_YQ="$CLASHCTL_HOME/bin/yq"
+CLASH_CONFIG_RUNTIME="$CLASHCTL_HOME/resources/runtime.yaml"
+
+CLASHCTL_TEST_ACTIVE=1
+service_is_active() { [ "${CLASHCTL_TEST_ACTIVE:-1}" = 1 ]; }
+service_start() { return 0; }
+service_stop() { CLASHCTL_TEST_ACTIVE=0; }
+_get_bind_addr() { printf '127.0.0.1'; }
+_okcat() { printf '%s\n' "$*"; }
+_failcat() { printf '%s\n' "$*" >&2; return 1; }
+EOF
+
+cat >"$test_root/scripts/cmd/probe.sh" <<'EOF'
+clashprobe() {
+    local runtime=zsh
+    [ -n "${BASH_VERSION:-}" ] && runtime=bash
+    printf 'runtime=%s argument=%s\n' "$runtime" "$1"
+}
+EOF
+
+cat >"$test_root/probe.zsh" <<'EOF'
+CLASHCTL_HOME=$1
+export CLASHCTL_HOME
+. "$CLASHCTL_HOME/scripts/cmd/clashctl.sh"
+
+if (( $+functions[set_system_proxy] )); then
+    print -u2 'Bash implementation leaked into Zsh'
+    exit 91
+fi
+
+result=$(clashctl probe 'value with spaces') || exit
+[[ $result == 'runtime=bash argument=value with spaces' ]] || {
+    print -u2 -- "unexpected clashctl result: $result"
+    exit 92
+}
+
+result=$(clashprobe 'direct wrapper') || exit
+[[ $result == 'runtime=bash argument=direct wrapper' ]] || {
+    print -u2 -- "unexpected direct-wrapper result: $result"
+    exit 93
+}
+
+clashctl on --env-only >/dev/null 2>&1 || exit
+[[ $http_proxy == 'http://127.0.0.1:7897' ]] || {
+    print -u2 -- "proxy environment was not imported: ${http_proxy:-missing}"
+    exit 94
+}
+
+clashctl off --env-only >/dev/null 2>&1 || exit
+(( ! ${+http_proxy} && ! ${+https_proxy} && ! ${+all_proxy} )) || {
+    print -u2 'proxy environment was not removed'
+    exit 95
+}
+
+export CLASHCTL_MANAGE_SHELL_PROXY=0
+unset http_proxy https_proxy all_proxy
+clashctl on >/dev/null 2>&1 || exit
+(( ! ${+http_proxy} && ! ${+https_proxy} && ! ${+all_proxy} )) || {
+    print -u2 'externally managed proxy environment was overwritten by clashctl on'
+    exit 96
+}
+
+export http_proxy='owned-by-env-setup'
+clashctl off >/dev/null 2>&1 || exit
+[[ $http_proxy == 'owned-by-env-setup' ]] || {
+    print -u2 'externally managed proxy environment was cleared by clashctl off'
+    exit 97
+}
+
+print 'adapter-ok'
+EOF
+
+output=$(zsh -f "$test_root/probe.zsh" "$test_root" 2>&1)
+status=$?
+printf '%s\n' "$output"
+
+if [ "$status" -ne 0 ] || [ "$output" != adapter-ok ]; then
+    echo "FAIL: Zsh Bash adapter (status $status)"
+    exit 1
+fi
+
+cat >"$test_root/probe.bash" <<'EOF'
+CLASHCTL_HOME=$1
+export CLASHCTL_HOME CLASHCTL_MANAGE_SHELL_PROXY=0
+. "$CLASHCTL_HOME/scripts/cmd/clashctl.sh"
+
+unset http_proxy https_proxy all_proxy
+clashctl on >/dev/null 2>&1 || exit
+[ -z "${http_proxy+x}${https_proxy+x}${all_proxy+x}" ] || {
+    printf '%s\n' 'Bash clashctl on overwrote externally managed proxy variables' >&2
+    exit 98
+}
+
+export http_proxy=owned-by-env-setup
+clashctl off >/dev/null 2>&1 || exit
+[ "$http_proxy" = owned-by-env-setup ] || {
+    printf '%s\n' 'Bash clashctl off cleared externally managed proxy variables' >&2
+    exit 99
+}
+EOF
+
+if bash "$test_root/probe.bash" "$test_root"; then
+    echo 'PASS: Zsh delegates clashctl implementation to Bash'
+    echo 'PASS: Bash honors external proxy ownership'
+    exit 0
+fi
+
+echo 'FAIL: Bash external proxy ownership'
+exit 1


### PR DESCRIPTION
## 问题

安装器会把 `clashctl.sh` source 到当前 Zsh，但 `scripts/cmd/*.sh` 的实现实际按 Bash 编写。继续逐项修补 Bash/Zsh 语义差异，会让每个新子命令都重复承担跨 shell 兼容成本。

Related to #617.

## 方案

- Bash 仍直接加载现有实现；
- Zsh 只加载一个薄适配层，保留 `clashctl`/`clash*` 函数入口，并把命令与参数原样交给 Bash 子进程；
- 不修改 `node`、`sub` 等业务实现来迎合 Zsh；
- `on/off` 默认保持现有父 shell 代理变量行为；设置 `CLASHCTL_MANAGE_SHELL_PROXY=0` 后，无参数 `clashctl on/off` 只管理服务，不写入或清除外部工具拥有的代理变量；显式 `--env-only` 仍然可用；
- Bash、Zsh 和 Fish 入口都遵守该代理所有权开关。

PR #618 的交互输入修复保持独立，本 PR 不包含它。

## 测试

新增 `tests/test_zsh_bash_adapter.sh`，覆盖：

- Zsh 不加载 Bash 实现函数；
- 公共 `clashctl` 和直接 `clash*` 入口都在 Bash 中运行；
- 含空格参数原样转发；
- 默认代理环境桥接仍可用；
- `CLASHCTL_MANAGE_SHELL_PROXY=0` 时，Bash/Zsh 均保留外部代理变量。

干净分支已通过 Bash/Zsh 语法检查和适配器测试；与 PR #618 临时叠加后，粘贴、方向键及非 TTY 回归也全部通过。NAS Ubuntu 26.04 / Zsh 5.9 已撤掉旧的逐项 `node` 兼容补丁，真实 Mihomo API 下的订阅列表和 `clashctl node ls` 仍正常。