### PR TITLE
fix(install): avoid keeping partial downloads

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -211,6 +211,8 @@ download_zip() {
         url="$proxy_url"
         _okcat '⏳' "正在下载：${item}：$url"
         local target="${ZIP_BASE_DIR}/$(basename "$url")"
+        local temp_target="${ZIP_BASE_DIR}/.$(basename "$url").part"
+        rm -f -- "$temp_target"
         curl \
             --progress-bar \
             --show-error \
@@ -219,8 +221,12 @@ download_zip() {
             --location \
             --max-time "$CLASHCTL_DOWNLOAD_TIMEOUT" \
             --retry 1 \
-            --output "$target" \
-            "$url"
+            --output "$temp_target" \
+            "$url" || {
+            rm -f -- "$temp_target"
+            exit 1
+        }
+        /bin/mv -f -- "$temp_target" "$target"
         target_zips+=("$target")
     done
     valid_zip "${target_zips[@]}"


### PR DESCRIPTION
## Summary

- Download archives into a hidden `.part` file first.
- Remove the temporary file when `curl` fails.
- Rename the temporary file to the final archive name only after a successful download.

This prevents an interrupted download from being picked up as an existing archive on the next install attempt.

## Validation

- `bash -n scripts/preflight.sh`
- Simulated a failed `curl`: no final archive or temporary file remained.
- Simulated a successful `curl`: the temporary file was renamed to the final archive.

Fixes #616