### PR TITLE
fix(service): 修正服务文件权限（-m +x 实为 0111）并补充失败检查

### DIFF
--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -212,36 +212,48 @@ service_read_log() {
 install_service() {
     detect_service_manager
 
-    local template_dir="${CLASHCTL_SRC}/scripts/init"
+    # CLASHCTL_SRC 只由 install.sh / uninstall.sh 设置，运行期 shell 中为空；
+    # 回退到安装目录，install_clashctl 已把 scripts/init 复制过去。
+    local template_dir="${CLASHCTL_SRC:-$CLASHCTL_HOME}/scripts/init"
     local kernel_desc="$CLASHCTL_KERNEL Daemon, A[nother] Clash Kernel."
     local cmd_path="${BIN_KERNEL}"
     local cmd_arg="-d ${CLASH_RESOURCES_DIR} -f ${CLASH_CONFIG_RUNTIME}"
     local cmd_full="${BIN_KERNEL} -d ${CLASH_RESOURCES_DIR} -f ${CLASH_CONFIG_RUNTIME}"
-    local service_src service_target
+    local service_src service_target service_mode
 
     case "$service_manager" in
     systemd)
         service_src="${template_dir}/systemd.sh"
         service_target="/etc/systemd/system/${CLASHCTL_KERNEL}.service"
+        # unit 文件只被读取，不会被执行。此前的 `-m +x` 会编译成 0111：
+        # systemd 以 root 身份仍能加载，但会记录 "marked executable" 警告，
+        # 而任何非特权工具都读不回来。
+        service_mode=0644
         ;;
     sysvinit)
         service_src="${template_dir}/sysvinit.sh"
         service_target="/etc/init.d/${CLASHCTL_KERNEL}"
+        service_mode=0755
         ;;
     openrc)
         service_src="${template_dir}/openrc.sh"
         service_target="/etc/init.d/${CLASHCTL_KERNEL}"
+        service_mode=0755
         ;;
     runit)
         service_src="${template_dir}/runit.sh"
         service_target="/etc/sv/${CLASHCTL_KERNEL}/run"
+        service_mode=0755
         ;;
     nohup | *)
         return 0
         ;;
     esac
 
-    /usr/bin/install -D -m +x "$service_src" "$service_target"
+    /usr/bin/install -D -m "$service_mode" "$service_src" "$service_target" || {
+        _failcat '❌' "写入服务文件失败：$service_target"
+        return 1
+    }
     sed -i \
         -e "s#placeholder_cmd_path#$cmd_path#g" \
         -e "s#placeholder_cmd_args#$cmd_arg#g" \
@@ -250,7 +262,10 @@ install_service() {
         -e "s#placeholder_pid_path#$service_pid_path#g" \
         -e "s#placeholder_kernel_name#$CLASHCTL_KERNEL#g" \
         -e "s#placeholder_kernel_desc#$kernel_desc#g" \
-        "$service_target"
+        "$service_target" || {
+        _failcat '❌' "服务文件模板替换失败：$service_target"
+        return 1
+    }
 
     case "$service_manager" in
     systemd)


### PR DESCRIPTION
## 问题

`scripts/lib/service.sh` 中生成服务文件的这一行：

```bash
/usr/bin/install -D -m +x "$service_src" "$service_target"
```

`+x` 是符号模式，GNU install 以 **0 为基准**编译它，结果是 `0111`（`--x--x--x`），而不是预期的可执行权限。

实测（coreutils 8.32）：

```console
$ /usr/bin/install -D -m +x src.txt out
$ stat -c '%a %A' out
111 ---x--x--x
$ cat out
cat: out: Permission denied      # 属主自己都读不了
```

影响分两种：

- **systemd**：PID 1 是 root，仍能加载该 unit，但会记录告警。`systemd-analyze verify` 直接复现：
  ```console
  Configuration file /.../exec.service is marked executable.
  Please remove executable permission bits. Proceeding anyway.
  ```
  非 root 的工具链（`systemctl cat`、编辑器）则完全读不到。
- **sysvinit / openrc / runit**：脚本同样落成 `0111`。shell 脚本没有读权限根本无法执行，非 root 调用 `service <name> start` 会失败。

之所以一直没被发现，是因为 `install_service` 以 root 运行，`DAC_OVERRIDE` 让紧随其后的 `sed -i` 仍能读回文件。

## 改动

1. 按服务管理器指定显式权限：systemd unit 用 `0644`，三个 init 脚本用 `0755`。
2. 给 `install` 和 `sed` 补失败检查。此前写入失败也会继续往下走并打印「已注册 systemd 服务」，把真正的错误盖掉。
3. `template_dir` 回退到 `$CLASHCTL_HOME`：`CLASHCTL_SRC` 只由 `install.sh` / `uninstall.sh` 设置，运行期 shell 中为空；而安装时 `install_clashctl` 已把 `scripts/init` 复制进安装目录，回退后两种上下文都正确。

## 验证

- `bash -n` + `shellcheck`（仓库自带 `.shellcheckrc`）：告警数与改动前一致，无新增。
- 按 `install_service` 的方式渲染 systemd 模板后 `systemd-analyze verify`：`0644` 无任何告警；`0111` 复现上面的 `Permission denied`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ybaBXsSrVnmYE6GxjJ7JH
