### PR TITLE
fix(systemd): 移除 LimitNPROC 并精简无用 capability

### DIFF
--- a/scripts/init/systemd.sh
+++ b/scripts/init/systemd.sh
@@ -4,10 +4,21 @@ After=network.target NetworkManager.service systemd-networkd.service iwd.service
 
 [Service]
 Type=simple
-LimitNPROC=500
 LimitNOFILE=1000000
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+# 默认以 root 运行。若要以普通用户运行，取消下面 User= 的注释；
+# AmbientCapabilities 这一行正是为此准备的。
+#   User=mihomo
+#
+# 不要再把 LimitNPROC 加回来。它限制的是该*用户*在全系统的任务总数，
+# 配合 User= 时，普通桌面账户轻易超过 1500 个线程，systemd 在 setuid
+# 之后 exec 会直接 EAGAIN，报成 status=203/EXEC——而 203/EXEC 的字面
+# 含义是「找不到或不可执行」，会把人引向完全无关的方向。
+#
+# CAP_SYS_TIME（修改系统时钟）与 CAP_SYS_PTRACE（调试任意进程）对代理
+# 内核毫无用处，已刻意移除。CAP_DAC_* 保留：服务以 root 运行，但要向
+# 可能属于安装用户的 resources 目录写入 cache.db 和日志。
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
 Restart=always
 ExecStartPre=/usr/bin/sleep 1s
 ExecStart=placeholder_cmd_full


### PR DESCRIPTION
## 问题

`scripts/init/systemd.sh` 目前是：

```ini
[Service]
Type=simple
LimitNPROC=500
LimitNOFILE=1000000
CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SYS_TIME CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
```

### `LimitNPROC=500`

模板没有 `User=`，服务以 root 运行，这一行恰好无害（root 不受 `RLIMIT_NPROC` 约束）。

但只要有人按最小权限的做法加上 `User=`——而 `AmbientCapabilities` 这一行正是为此准备的——它立刻变成致命项：`RLIMIT_NPROC` 统计的是**该用户在全系统的任务总数**，普通桌面账户（tmux / 编辑器 / conda）轻易超过 1500，systemd 在 setuid 之后 exec 直接 `EAGAIN`。

对外表现是 `status=203/EXEC`，而 203/EXEC 的字面含义是「找不到或不可执行」——会让人去反复检查 `ExecStart=` 的路径和权限，方向完全错。

### 多余的 capability

`CAP_SYS_TIME`（修改系统时钟）和 `CAP_SYS_PTRACE`（调试任意进程）对一个代理内核没有任何用途。

## 改动

- 移除 `LimitNPROC`，并在注释里写明为什么不能加回来。
- 从两条 capability 行中移除 `CAP_SYS_TIME` 与 `CAP_SYS_PTRACE`。
- **保留 `CAP_DAC_READ_SEARCH` / `CAP_DAC_OVERRIDE`**：服务虽以 root 运行，但要向可能属于安装用户的 `resources` 目录写入 `cache.db` 与日志，从 `CapabilityBoundingSet` 里去掉会有实际风险。
- 注释中给出 `User=` 示例。

## 验证

渲染模板后 `systemd-analyze verify`，无告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ybaBXsSrVnmYE6GxjJ7JH
