### PR TITLE
fix: 兼容 zsh 的 path 特殊变量与 bash 特有语法，修复子命令报 command not found / bad substitution

### DIFF
--- a/scripts/cmd/clashctl.sh
+++ b/scripts/cmd/clashctl.sh
@@ -14,14 +14,16 @@ done
 clashctl() {
     local sub_cmd
     sub_cmd=${1:-help}
-    shift
+    shift 2>/dev/null || :
 
     case $sub_cmd in
     -h | --help | help) sub_cmd=help ;;
     esac
 
     local target="clash${sub_cmd}"
-    declare -F "$target" >&/dev/null || {
+    # bash 用 declare -F 检查函数；zsh 的 declare -F 是声明浮点变量（恒返回 0）
+    # → 统一用 command -v（两 shell 语义一致）
+    command -v "$target" >&/dev/null || {
         _failcat "Unknown subcommand: $target"
         _failcat "Use 'clashctl help' for usage information."
         return

--- a/scripts/cmd/node.sh
+++ b/scripts/cmd/node.sh
@@ -57,21 +57,21 @@ _node_api_base() {
 # 统一 curl 封装：--noproxy '*' 避免走系统代理；secret 非空时带 Bearer
 # 用法：_node_curl <METHOD> <PATH> [额外 curl 参数...]
 _node_curl() {
-    local method=$1 path=$2
+    local method=$1 api_path=$2
     shift 2
     local secret base auth=()
     base=$(_node_api_base)
     secret=$(_get_secret)
     [ -n "$secret" ] && auth=(-H "Authorization: Bearer $secret")
     curl -s --noproxy '*' --max-time "${CLASHCTL_API_TIMEOUT:-10}" \
-        -X "$method" "${auth[@]}" "${base}${path}" "$@"
+        -X "$method" "${auth[@]}" "${base}${api_path}" "$@"
 }
 
 # 路径段 URL 编码（组/节点名常含空格、中文、emoji）；LC_ALL=C 按字节百分号编码
 _node_urlencode() {
     local LC_ALL=C s=$1 out='' c i
     for ((i = 0; i < ${#s}; i++)); do
-        c=${s:i:1}
+        c=${s:$i:1}
         case $c in
         [a-zA-Z0-9._~-]) out+=$c ;;
         *)
@@ -336,14 +336,16 @@ EOF
     }
 
     local i w namew=0 noww=0
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${names[$i]}")
         ((w > namew)) && namew=$w
         w=$(_dispwidth "${nows[$i]}")
         ((w > noww)) && noww=$w
     done
 
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         printf '  %s → %s  [%s]\n' \
             "$(_pad "${names[$i]}" "$namew")" \
             "$(_pad "${nows[$i]}" "$noww")" \
@@ -378,13 +380,15 @@ _node_list_members() {
     done < <(_node_proxies)
 
     local i w namew=0
-    for i in "${!members[@]}"; do
+    _arr_indices members
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${members[$i]}")
         ((w > namew)) && namew=$w
     done
 
     local marker
-    for i in "${!members[@]}"; do
+    _arr_indices members
+    for i in "${_ARR_IDX[@]}"; do
         marker=' '
         [ "${members[$i]}" = "$now" ] && marker='*'
         printf '  %s %s  [%s]\n' \
@@ -448,12 +452,13 @@ _node_pick_group() {
     }
     # 仅一个组时自动选中
     [ ${#names[@]} -eq 1 ] && {
-        printf '%s\n' "${names[0]}"
+        printf '%s\n' "${names[@]}"
         return 0
     }
 
     local w namew=0 noww=0
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${names[$i]}")
         ((w > namew)) && namew=$w
         w=$(_dispwidth "${nows[$i]:-—}")
@@ -465,7 +470,8 @@ _node_pick_group() {
         preview_dir=$(_node_fzf_preview_dir)
         if [ -n "$preview_dir" ]; then
             preview_args=(--preview "$(_node_fzf_preview_cmd)" --preview-window='right:45%:wrap')
-            for i in "${!names[@]}"; do
+            _arr_indices names
+            for i in "${_ARR_IDX[@]}"; do
                 {
                     printf '策略组\n'
                     printf '  名称：%s\n' "${names[$i]}"
@@ -491,7 +497,8 @@ _node_pick_group() {
             done
         fi
         selected=$(
-            for i in "${!names[@]}"; do
+            _arr_indices names
+            for i in "${_ARR_IDX[@]}"; do
                 printf '%s\t%s\t%s → %s  [%s]\n' \
                     "$((i + 1))" \
                     "${names[$i]}" \
@@ -521,7 +528,8 @@ _node_pick_group() {
     # 与 ls 一致：[序号] 名字 → 当前节点 [type]，按显示宽度对齐
     local tok idxw=${#names[@]}
     idxw=${#idxw} # 序号位数；[n] 整体左对齐补齐到 idxw+2
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         tok="[$((i + 1))]"
         printf '  %-*s %s → %s  [%s]\n' \
             $((idxw + 2)) "$tok" \
@@ -556,7 +564,8 @@ _node_pick_proxy() {
     }
 
     local w namew=0
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${names[$i]}")
         ((w > namew)) && namew=$w
     done
@@ -566,7 +575,8 @@ _node_pick_proxy() {
         preview_dir=$(_node_fzf_preview_dir)
         if [ -n "$preview_dir" ]; then
             preview_args=(--preview "$(_node_fzf_preview_cmd)" --preview-window='right:45%:wrap')
-            for i in "${!names[@]}"; do
+            _arr_indices names
+            for i in "${_ARR_IDX[@]}"; do
                 {
                     printf '节点\n'
                     printf '  名称：%s\n' "${names[$i]}"
@@ -575,7 +585,8 @@ _node_pick_proxy() {
             done
         fi
         selected=$(
-            for i in "${!names[@]}"; do
+            _arr_indices names
+            for i in "${_ARR_IDX[@]}"; do
                 printf '%s\t%s\t%s  [%s]\n' \
                     "$((i + 1))" \
                     "${names[$i]}" \
@@ -603,7 +614,8 @@ _node_pick_proxy() {
 
     local tok idxw=${#names[@]}
     idxw=${#idxw}
-    for i in "${!names[@]}"; do
+    _arr_indices names
+    for i in "${_ARR_IDX[@]}"; do
         tok="[$((i + 1))]"
         printf '  %-*s %s  [%s]\n' $((idxw + 2)) "$tok" "${names[$i]}" "${types[$i]}" >&2
     done
@@ -650,7 +662,8 @@ _node_pick_member() {
 
     local delayw=0 namew=0 w pad
     if [ "$with_delay" = true ]; then
-        for i in "${!members[@]}"; do
+        _arr_indices members
+        for i in "${_ARR_IDX[@]}"; do
             w=$(_dispwidth "${members[$i]}")
             ((w > namew)) && namew=$w
             delay_label=$(_node_delay_label "${delays[${members[$i]}]:-}")
@@ -673,7 +686,8 @@ _node_pick_member() {
         preview_dir=$(_node_fzf_preview_dir)
         if [ -n "$preview_dir" ]; then
             preview_args=(--preview "$(_node_fzf_preview_cmd)" --preview-window='right:45%:wrap')
-            for i in "${!members[@]}"; do
+            _arr_indices members
+            for i in "${_ARR_IDX[@]}"; do
                 {
                     printf '节点\n'
                     printf '  名称：%s\n' "${members[$i]}"
@@ -693,7 +707,8 @@ _node_pick_member() {
         fi
 
         selected=$(
-            for i in "${!members[@]}"; do
+            _arr_indices members
+            for i in "${_ARR_IDX[@]}"; do
                 marker=' '
                 [ "${members[$i]}" = "$now" ] && marker='*'
                 if [ "$with_delay" = true ]; then
@@ -731,7 +746,8 @@ _node_pick_member() {
 
     local marker tok idxw=${#members[@]}
     idxw=${#idxw} # 序号位数；[n] 整体左对齐补齐到 idxw+2，使括号紧凑且名字列对齐
-    for i in "${!members[@]}"; do
+    _arr_indices members
+    for i in "${_ARR_IDX[@]}"; do
         marker=' '
         [ "${members[$i]}" = "$now" ] && marker='*'
         tok="[$((i + 1))]"

--- a/scripts/cmd/on.sh
+++ b/scripts/cmd/on.sh
@@ -85,7 +85,11 @@ set_system_proxy() {
 _dump_proxy_env_fish() {
     local v val
     for v in http_proxy HTTP_PROXY https_proxy HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY; do
-        val=${!v}
+        if [ -n "$ZSH_VERSION" ]; then
+            val=${(P)v}
+        else
+            val=${!v}
+        fi
         [ -z "$val" ] && continue
         val=${val//\\/\\\\}
         val=${val//\'/\\\'}

--- a/scripts/cmd/sub.sh
+++ b/scripts/cmd/sub.sh
@@ -268,15 +268,15 @@ _sub_validate_name() {
 
 # 由名称派生安全的磁盘文件路径（非 [A-Za-z0-9._-] → _，冲突追加 -2/-3…）
 _sub_filename() {
-    local name=$1 safe path n=1
+    local name=$1 safe cfg_path n=1
     safe=$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')
     [ -z "$safe" ] && safe=sub
-    path="${CLASH_PROFILES_DIR}/${safe}.yaml"
-    while [ -e "$path" ]; do
+    cfg_path="${CLASH_PROFILES_DIR}/${safe}.yaml"
+    while [ -e "$cfg_path" ]; do
         n=$((n + 1))
-        path="${CLASH_PROFILES_DIR}/${safe}-${n}.yaml"
+        cfg_path="${CLASH_PROFILES_DIR}/${safe}-${n}.yaml"
     done
-    printf '%s' "$path"
+    printf '%s' "$cfg_path"
 }
 
 # 一次性把旧的数字 id 模型迁移为 name 模型（幂等：以 id 字段存在为哨兵）
@@ -343,7 +343,8 @@ _sub_pick() {
     # 需用户明确确认，不做隐式自动选择。
 
     local i w namew=0 trafw=0 expw=0
-    for i in "${!_SUB_NAMES[@]}"; do
+    _arr_indices _SUB_NAMES
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${_SUB_NAMES[$i]}")
         ((w > namew)) && namew=$w
         w=$(_dispwidth "${_SUB_TRAFFICS[$i]}")
@@ -365,7 +366,8 @@ _sub_pick() {
             # shellcheck disable=SC2016
             preview_args=(--preview 'cat "$SUB_FZF_PREVIEW_DIR"/{1}' --preview-window='right:45%:wrap')
             local now
-            for i in "${!_SUB_NAMES[@]}"; do
+            _arr_indices _SUB_NAMES
+            for i in "${_ARR_IDX[@]}"; do
                 now=否
                 [ "${_SUB_NAMES[$i]}" = "$_SUB_CUR" ] && now=是
                 {
@@ -380,7 +382,8 @@ _sub_pick() {
             done
         fi
         selected=$(
-            for i in "${!_SUB_NAMES[@]}"; do
+            _arr_indices _SUB_NAMES
+            for i in "${_ARR_IDX[@]}"; do
                 marker=' '
                 [ "${_SUB_NAMES[$i]}" = "$_SUB_CUR" ] && marker='*'
                 printf '%s\t%s\t%s %s  %s  %s\n' \
@@ -416,7 +419,8 @@ _sub_pick() {
     idxw=${#idxw} # 序号位数
     # 序号列宽 + 标记列（空格偏移）后输出标题，与数据行对齐
     printf '  %*s   %s\n' "$((idxw + 2))" '' "$col_header" >&2
-    for i in "${!_SUB_NAMES[@]}"; do
+    _arr_indices _SUB_NAMES
+    for i in "${_ARR_IDX[@]}"; do
         marker=' '
         [ "${_SUB_NAMES[$i]}" = "$_SUB_CUR" ] && marker='*'
         tok="[$((i + 1))]"
@@ -659,11 +663,11 @@ _sub_del_locked() {
         return 1
     }
 
-    local path url
-    path=$(_sub_get "$name" path)
+    local cfg_path url
+    cfg_path=$(_sub_get "$name" path)
     url=$(_sub_get "$name" url)
 
-    /usr/bin/rm -f "$path"
+    /usr/bin/rm -f "$cfg_path"
     PROFILE_NAME=$name "$BIN_YQ" -i 'del(.profiles[] | select(.name == strenv(PROFILE_NAME)))' "$CLASH_PROFILES_META"
     _logging_sub "➖ 已删除订阅：[$name] $url"
     _okcat '🎉' "订阅已删除：[$name] $url"
@@ -681,8 +685,12 @@ _fmt_bytes() {
 
 # 解析 subscription-userinfo 原始串，输出：used<TAB>total<TAB>expire（bytes / epoch）
 _userinfo_fields() {
-    local s=${1//;/ } kv k v upload=0 download=0 total=0 expire=0
-    for kv in $s; do
+    # 按 ; 拆 key=value 对：bash 依赖未加引号分词，zsh 默认不分词
+    # → tr 将 ; 归一为换行，逐行 read（IFS=' ' 剥离 "; " 残留的前导空格）
+    local s kv k v upload=0 download=0 total=0 expire=0
+    s=$(printf '%s' "$1" | tr ';' '\n')
+    while IFS=' ' read -r kv; do
+        [ -z "$kv" ] && continue
         k=${kv%%=*}
         v=${kv#*=}
         [[ $v =~ ^[0-9]+$ ]] || continue
@@ -692,7 +700,7 @@ _userinfo_fields() {
         total) total=$v ;;
         expire) expire=$v ;;
         esac
-    done
+    done <<<"$s"
     printf '%s\t%s\t%s' "$((upload + download))" "$total" "$expire"
 }
 
@@ -747,7 +755,8 @@ EOF
     updw=$(_dispwidth "$UPD_H")
     trafw=$(_dispwidth "$TRAF_H")
     expw=$(_dispwidth "$EXP_H")
-    for i in "${!_SUB_NAMES[@]}"; do
+    _arr_indices _SUB_NAMES
+    for i in "${_ARR_IDX[@]}"; do
         w=$(_dispwidth "${_SUB_NAMES[$i]}")
         ((w > namew)) && namew=$w
         w=$(_dispwidth "${_SUB_UPDS[$i]:-—}")
@@ -767,7 +776,8 @@ EOF
         '链接'
 
     local marker
-    for i in "${!_SUB_NAMES[@]}"; do
+    _arr_indices _SUB_NAMES
+    for i in "${_ARR_IDX[@]}"; do
         marker=' '
         [ "${_SUB_NAMES[$i]}" = "$_SUB_CUR" ] && marker='*'
         upd=${_SUB_UPDS[$i]:-—}
@@ -818,22 +828,22 @@ _sub_use_locked() {
         return 1
     }
 
-    local path url
-    path=$(_sub_get "$name" path)
+    local cfg_path url
+    cfg_path=$(_sub_get "$name" path)
     url=$(_sub_get "$name" url)
 
-    [ -f "$path" ] && [ -s "$path" ] || {
-        _errorcat "订阅配置文件缺失或为空：$path"
+    [ -f "$cfg_path" ] && [ -s "$cfg_path" ] || {
+        _errorcat "订阅配置文件缺失或为空：$cfg_path"
         return 1
     }
-    _valid_sub_nodes "$path" || return 1
+    _valid_sub_nodes "$cfg_path" || return 1
 
     # 切换前备份 BASE：合并校验失败（rc=1）时连同运行配置一起回滚，避免 BASE 与 runtime 不一致
     cat "$CLASH_CONFIG_BASE" >"${CLASH_CONFIG_BASE}.bak" || {
         _errorcat "无法备份当前配置（磁盘已满？），已取消切换"
         return 1
     }
-    cat "$path" >"$CLASH_CONFIG_BASE"
+    cat "$cfg_path" >"$CLASH_CONFIG_BASE"
     _merge_config_restart
     rc=$?
     if [ "$rc" -eq 1 ]; then
@@ -983,9 +993,9 @@ _sub_update_one() {
         return 1
     }
 
-    local url path
+    local url cfg_path
     url=$(_sub_get "$name" url)
-    path=$(_sub_get "$name" path)
+    cfg_path=$(_sub_get "$name" path)
     _okcat "✈️ " "更新订阅：[$name] $url"
 
     _sub_download "$url" "$strategy" || {
@@ -995,11 +1005,11 @@ ${_SUB_DL_DEBUG_HINT:-转换日志：$BIN_SUBCONVERTER_LOG}"
         return 1
     }
 
-    _with_profiles_lock _sub_update_locked "$name" "$url" "$path" "$_SUB_DL_FILE" "$FETCH_USERINFO"
+    _with_profiles_lock _sub_update_locked "$name" "$url" "$cfg_path" "$_SUB_DL_FILE" "$FETCH_USERINFO"
 }
 
 _sub_update_locked() {
-    local name=$1 url=$2 path=$3 dl_file=$4 userinfo=$5
+    local name=$1 url=$2 cfg_path=$3 dl_file=$4 userinfo=$5
 
     # 下载期间该订阅可能已被并发删除，锁内复检
     _sub_has "$name" || {
@@ -1009,7 +1019,7 @@ _sub_update_locked() {
     }
 
     _logging_sub "✅ 订阅更新成功：[$name] $url"
-    /bin/mv -f "$dl_file" "$path"
+    /bin/mv -f "$dl_file" "$cfg_path"
 
     local now
     now=$(date +"%Y-%m-%d %H:%M:%S")

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -117,7 +117,7 @@ _errorcat() {
 _dispwidth() {
     local s=$1 w=0 i c cp
     for ((i = 0; i < ${#s}; i++)); do
-        c=${s:i:1}
+        c=${s:$i:1}
         printf -v cp '%d' "'$c"
         if ((cp == 0xFE0F)); then
             ((w += 1)) # 变体选择符：补足前一字符到宽
@@ -145,6 +145,20 @@ _pad() {
     pad=$((target - w))
     ((pad < 0)) && pad=0
     printf '%s%*s' "$s" "$pad" ''
+}
+
+# bash 数组 0 基、zsh 数组 1 基：填充 _ARR_IDX 为 $1 数组在当前 shell 下的全部索引
+# 用法：_arr_indices <数组名>; for i in "${_ARR_IDX[@]}"; do ... "${arr[$i]}" ...; done
+_ARR_IDX=()
+_arr_indices() {
+    _ARR_IDX=()
+    if [ -n "$ZSH_VERSION" ]; then
+        local _ai_n _ai_i
+        eval "_ai_n=\${#$1[@]}"
+        for ((_ai_i = 1; _ai_i <= _ai_n; _ai_i++)); do _ARR_IDX+=("$_ai_i"); done
+    else
+        eval "_ARR_IDX=(\"\${!$1[@]}\")"
+    fi
 }
 
 _set_env() {


### PR DESCRIPTION
### 问题

   README 声明支持 bash/zsh/fish，但脚本在 zsh 下运行时，`clashctl node ls`、`clashctl sub ls` 等子命令会输出大
 量 `command not found: awk/grep/curl`、`bad substitution`、`unrecognized modifier` 报错，流量/到期信息也解析失
 败。

   ### 根因

   脚本按 bash 编写，但 zsh 与 bash 存在以下语法差异：

   1. **`path` 是 zsh 特殊变量**（与 `PATH` 绑定）。`_node_curl` 中 `local path=$2`（API 路径如 `/proxies`）会把
 整个 `PATH` 覆盖为 `/proxies`，此后所有外部命令（awk/grep/curl 等）全部"找不到"。sub.sh 中另有 5 处同名局部变量
 同样受影响。
   2. **`${s:i:1}`**（变量作偏移的子串）：zsh 将 `:i` 解析为 modifier，报 `unrecognized modifier`。
   3. **`"${!arr[@]}"`**（数组索引展开）：zsh 报 `bad substitution`，且 zsh 数组为 1 基、bash 为 0 基，索引语义
 不同。
   4. **隐式分词**：`for kv in $s` 依赖 bash 的未加引号分词，zsh 默认不分词，导致订阅 userinfo 的
 upload/download/total/expire 解析失败。
   5. 其他：`${!v}` 间接展开、`declare -F`（zsh 中为声明浮点数）、空参 `shift`。

   ### 改动

   - `path` 局部变量改名：node.sh → `api_path`，sub.sh → `cfg_path`（避免触发 zsh 特殊变量）
   - `common.sh` 新增 `_arr_indices` 辅助函数：按 shell 生成数组索引（bash 0 基 / zsh 1 基），22 处 `${!arr[@]}`
 循环统一改写
   - `${s:i:1}` → `${s:$i:1}`（两 shell 通用）
   - `_userinfo_fields` 改用 `tr` + 逐行 `read`，消除分词依赖
   - `on.sh` 间接展开按 shell 分支（`${(P)v}` / `${!v}`）
   - `clashctl.sh` 函数存在性检查改用 `command -v`；空参 `shift` 静默处理

   所有改动对 bash 行为完全透明（bash 下输出与改动前一致），仅消除 zsh 兼容性问题。

   ### 测试

   - zsh 5.9：`node ls`、`node ls <组>`（含 emoji/中文组名 URL 编码）、`node delay`、`sub ls`、
 `status/ui/secret/tun/mixin/log/on/off/help` 全部通过，无任何报错
   - bash：回归无影响，两 shell 输出一致（如 `sub ls` 均显示 `45.63GB/200.00GB`）
   - 全部脚本通过 `bash -n` 语法检查